### PR TITLE
docs: add initial implementation plan and ADR foundation

### DIFF
--- a/docs/adr/0001-tech-stack.md
+++ b/docs/adr/0001-tech-stack.md
@@ -1,0 +1,113 @@
+# ADR 0001 – Initial Tech Stack
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto soll als einfache lokale Web-Anwendung starten, die z. B. in einem Docker-Container auf einer NAS laufen kann.
+
+Geplanter Ablauf im MVP:
+
+- Bilder im Browser hochladen
+- Angebotsdaten strukturiert erzeugen
+- HTML-Vorlage befüllen
+- eBay-Draft vorbereiten
+- Ergebnisse prüfen
+
+Für den Start ist wichtig:
+
+- geringer technischer Overhead
+- lokal gut betreibbar
+- leicht verständlicher Stack
+- schnelle MVP-Umsetzung
+- gute Eignung für API-Integrationen und KI-nahe Logik
+
+## Entscheidung
+
+Für den Start verwenden wir:
+
+- **FastAPI** als Backend
+- **SQLite** als erste Persistenzlösung
+- **Docker** für Deployment und lokale/portable Ausführung
+- **server-rendered Frontend** mit leichtem HTML-Ansatz
+- optional **HTMX** für kleine interaktive UI-Verbesserungen ohne schweres SPA-Framework
+
+## Warum dieser Stack?
+
+### FastAPI
+
+- schlank und modern
+- gut für APIs und Dateiuploads
+- passt gut zu Python-basierten Integrationen
+- geeignet für KI-/Automatisierungslogik
+
+### SQLite
+
+- für den MVP völlig ausreichend
+- einfach zu betreiben
+- keine zusätzliche Datenbank-Infrastruktur nötig
+
+### Docker
+
+- ideal für Deployment auf einer NAS
+- reproduzierbares Setup
+- später leicht erweiterbar
+
+### Server-rendered Frontend
+
+- deutlich weniger Overhead als React/Vue im MVP
+- schnell umsetzbar
+- leicht verständlich
+- gut geeignet für Formulare, Uploads und Review-Seiten
+
+### HTMX
+
+HTMX ist eine kleine Bibliothek, mit der HTML-Seiten dynamischer werden können, ohne gleich ein großes Frontend-Framework einzuführen.
+
+Beispiele:
+- Upload-Status aktualisieren
+- Felder nachladen
+- Teile einer Seite neu rendern
+- Review-Bereiche aktualisieren
+
+Damit bleibt die App einfach, aber trotzdem angenehm interaktiv.
+
+## Konsequenzen
+
+### Positiv
+
+- schneller Start
+- wenig Komplexität
+- gut für Docker/NAS
+- Python eignet sich gut für Bilder, Templates und eBay-Integration
+
+### Negativ / bewusst in Kauf genommen
+
+- SQLite ist nicht die Endlösung für große Skalierung
+- HTMX ist weniger bekannt als React/Vue
+- bei stark wachsendem UI-Anspruch müsste das Frontend später evtl. ausgebaut werden
+
+## Nicht gewählt
+
+### React / Vue / Next.js
+
+Für den MVP unnötig schwergewichtig.
+
+### Node.js als Hauptbackend
+
+Wäre möglich, aber Python passt für den geplanten Mix aus Dateiverarbeitung, API-Integration und KI-Assistenz besser.
+
+### PostgreSQL direkt zum Start
+
+Für den MVP voraussichtlich unnötig aufwendig.
+
+## Nächster Schritt
+
+Auf Basis dieses Stacks sollten als Nächstes definiert werden:
+
+1. internes Draft-Datenmodell
+2. Upload- und Review-Flow
+3. Template-Platzhalter
+4. eBay-Auth-Handling

--- a/docs/adr/0002-draft-data-model.md
+++ b/docs/adr/0002-draft-data-model.md
@@ -1,0 +1,178 @@
+# ADR 0002 – Initial Draft Data Model
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto soll Verkaufsangebote aus Bildern und wenigen Zusatzinformationen vorbereiten.
+
+Dafür braucht das Projekt ein internes Datenmodell, das:
+
+- bildgestützte Eingaben aufnehmen kann
+- semantische Artikelinformationen strukturiert speichert
+- HTML-Templates befüllen kann
+- eBay-spezifische Felder ableiten kann
+- Review- und Draft-Zustände verwalten kann
+
+Wichtig ist eine Trennung zwischen:
+
+1. **generischen Listing-Daten**
+2. **plattform-spezifischen Feldern**
+3. **Prozess-/Statusinformationen**
+
+## Entscheidung
+
+Wir verwenden für den MVP ein internes Draft-Datenmodell mit drei Hauptblöcken:
+
+- `source`
+- `listing`
+- `marketplace`
+
+Zusätzlich kommt ein technischer Metablock hinzu:
+
+- `workflow`
+
+## Zielstruktur
+
+```json
+{
+  "id": "draft_...",
+  "source": {
+    "images": [],
+    "notes": "",
+    "userInput": {}
+  },
+  "listing": {
+    "title": "",
+    "subtitle": "",
+    "categorySuggestion": "",
+    "condition": "",
+    "brand": "",
+    "model": "",
+    "attributes": {},
+    "includedItems": [],
+    "issues": [],
+    "descriptionHtml": "",
+    "priceSuggestion": null,
+    "shippingSuggestion": {}
+  },
+  "marketplace": {
+    "ebay": {
+      "inventoryItemData": {},
+      "offerData": {},
+      "inventoryItemKey": null,
+      "offerId": null
+    }
+  },
+  "workflow": {
+    "status": "draft",
+    "needsReview": true,
+    "missingInformation": [],
+    "lastUpdatedAt": "",
+    "createdAt": ""
+  }
+}
+```
+
+## Bedeutung der Blöcke
+
+### `source`
+
+Enthält alles, was vom Nutzer oder aus dem Eingang kommt:
+
+- Bildpfade / Bildreferenzen
+- Freitextnotizen
+- manuelle Zusatzinfos
+- optionale Rohdaten
+
+### `listing`
+
+Enthält die fachliche Sicht auf das spätere Angebot:
+
+- Titel
+- Beschreibung
+- Zustand
+- Marke / Modell
+- Zubehör
+- Mängel
+- Preisvorschlag
+- Versandvorschlag
+
+Dieser Block bleibt möglichst **plattformneutral**.
+
+### `marketplace`
+
+Enthält Übersetzungen in marktplatzspezifische Felder.
+
+Im MVP zunächst:
+- nur `ebay`
+
+Dort liegen z. B.:
+- Inventory-Item-Daten
+- Offer-Daten
+- externe IDs
+
+### `workflow`
+
+Enthält Steuerungs- und Statusinfos:
+
+- aktueller Bearbeitungsstatus
+- Review-Bedarf
+- fehlende Angaben
+- Zeitstempel
+
+## Beispiel für erste Statuswerte
+
+Mögliche Werte für `workflow.status`:
+
+- `draft`
+- `classified`
+- `ready_for_review`
+- `ready_for_marketplace`
+- `offer_created`
+- `published`
+- `blocked`
+
+## Warum dieses Modell?
+
+### Vorteile
+
+- klare Trennung zwischen Semantik und API-Feldern
+- HTML-Template kann aus `listing` befüllt werden
+- eBay-Logik bleibt in `marketplace.ebay`
+- spätere Plattformen können ergänzt werden
+- Workflow bleibt nachvollziehbar
+
+### Nachteile
+
+- etwas mehr Strukturaufwand am Anfang
+- anfangs mehr Mapping-Arbeit zwischen Blöcken
+
+## Nicht gewählt
+
+### Direkt nur eBay-Felder modellieren
+
+Nicht gewählt, weil das Modell dann zu früh zu stark an eBay gebunden wäre.
+
+### Freie JSON-Strukturen ohne klares Schema
+
+Nicht gewählt, weil das schnell unübersichtlich und fehleranfällig wird.
+
+## Konsequenzen
+
+- HTML-Rendering greift primär auf `listing` zu
+- eBay-API-Übersetzung greift primär auf `listing` + `marketplace.ebay` zu
+- Review-UI zeigt `listing` + `workflow.missingInformation`
+- Bilder und Rohinput bleiben in `source`
+
+## Nächster Schritt
+
+Als Nächstes sollte der konkrete **Upload- und Review-Flow** festgelegt werden:
+
+1. Bilder hochladen
+2. Draft erzeugen
+3. Draft prüfen
+4. HTML rendern
+5. eBay-Offer erstellen

--- a/docs/adr/0003-upload-and-review-flow.md
+++ b/docs/adr/0003-upload-and-review-flow.md
@@ -1,0 +1,179 @@
+# ADR 0003 – Upload and Review Flow
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto soll im MVP als einfache Web-Anwendung funktionieren:
+
+- Nutzer lädt Bilder hoch
+- System erzeugt einen Draft
+- Nutzer prüft und korrigiert den Draft
+- HTML wird erzeugt
+- eBay-Draft / Offer wird vorbereitet
+
+Damit dieser Ablauf verständlich und robust bleibt, braucht es einen klaren Upload- und Review-Flow.
+
+## Entscheidung
+
+Der MVP verwendet einen linearen Flow mit klaren Schritten:
+
+1. **Upload**
+2. **Analyse / Draft-Erzeugung**
+3. **Review**
+4. **Template-Rendering**
+5. **Marketplace-Draft-Erstellung**
+6. **Ergebnis / nächste Aktion**
+
+## Geplanter Ablauf
+
+### 1. Upload
+
+Der Nutzer lädt hoch:
+
+- 1 bis n Bilder
+- optionale Notizen
+- optionale manuelle Zusatzinfos
+
+Beispiele:
+- Produktname, falls bekannt
+- Zustand
+- Zubehör
+- besondere Hinweise
+
+### 2. Analyse / Draft-Erzeugung
+
+Die Anwendung erzeugt daraus einen ersten Draft:
+
+- Artikeltyp
+- Marke / Modell
+- Zustand
+- Zubehörumfang
+- erkannte Mängel / Unsicherheiten
+- Vorschlag für Titel
+- Vorschlag für Beschreibung
+- Vorschlag für Kategorie
+
+Wichtig:
+- Unklarheiten werden nicht versteckt, sondern als fehlende Information markiert
+
+### 3. Review
+
+Der Nutzer bekommt eine Review-Seite mit:
+
+- Bildern
+- strukturierten Draft-Daten
+- fehlenden / unsicheren Angaben
+- HTML-Vorschau
+
+Der Nutzer kann dabei:
+
+- Felder korrigieren
+- Angaben ergänzen
+- Entwurf bestätigen
+
+### 4. Template-Rendering
+
+Nach Bestätigung wird das HTML-Gerüst final befüllt.
+
+Dabei soll die App:
+- strukturierte Felder in das Template einsetzen
+- eine finale HTML-Beschreibung erzeugen
+- diese Beschreibung speicherbar und erneut renderbar halten
+
+### 5. Marketplace-Draft-Erstellung
+
+Nach erfolgreichem Review erzeugt die App:
+
+- eBay Inventory Item
+- eBay Offer
+- zunächst **nicht veröffentlicht**
+
+### 6. Ergebnis
+
+Die App zeigt danach:
+
+- lokalen Draft-Status
+- externe eBay-IDs
+- Status wie z. B. `offer_created`
+- nächsten sinnvollen Schritt
+
+## UI-Prinzipien für den MVP
+
+Die Oberfläche soll bewusst einfach bleiben.
+
+### Bevorzugt
+- server-rendered Seiten
+- klassische Formulare
+- wenige klare Ansichten
+
+### Nicht nötig im MVP
+- komplexe Single-Page-App
+- Live-Collaboration
+- umfangreiche Drag-and-Drop-Workflows
+
+## Minimale Seiten / Ansichten
+
+Für den MVP reichen voraussichtlich:
+
+1. **Upload-Seite**
+2. **Draft-/Review-Seite**
+3. **Ergebnis-/Status-Seite**
+
+Optional später:
+- Draft-Liste
+- erneute Bearbeitung bestehender Drafts
+- Veröffentlichungs-Ansicht
+
+## Fehler- und Blockerlogik
+
+Wenn Informationen fehlen oder unklar sind:
+
+- Draft bleibt im Review-Zustand
+- `workflow.missingInformation` wird gefüllt
+- Nutzer muss bestätigen oder ergänzen
+
+Wenn Marketplace-Erstellung fehlschlägt:
+
+- Draft bleibt lokal erhalten
+- Fehler wird separat ausgewiesen
+- erneuter Versuch muss möglich sein
+
+## Warum dieser Flow?
+
+### Vorteile
+
+- einfach verständlich
+- gut für MVP
+- klare Übergänge
+- manuelle Qualitätskontrolle vor externer Aktion
+
+### Nachteile
+
+- noch kein stark paralleler Workflow
+- manuelle Review bleibt notwendig
+
+## Nicht gewählt
+
+### Vollautomatische Veröffentlichung ohne Review
+
+Nicht gewählt, weil das am Anfang zu riskant ist.
+
+### Sehr freier, unstrukturierter Bearbeitungsfluss
+
+Nicht gewählt, weil das für den MVP unnötig komplex wäre.
+
+## Konsequenzen
+
+- Review ist Pflicht vor eBay-Draft-Erstellung
+- Draft-Erzeugung und Draft-Prüfung sind getrennte Schritte
+- UI bleibt schlicht und robust
+
+## Nächster Schritt
+
+Als Nächstes sollte festgelegt werden:
+
+1. wie das HTML-Template technisch eingebunden wird
+2. welche Template-Platzhalter standardisiert unterstützt werden

--- a/docs/adr/0004-template-and-placeholders.md
+++ b/docs/adr/0004-template-and-placeholders.md
@@ -1,0 +1,146 @@
+# ADR 0004 – HTML Template and Placeholder Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Für Open Inserto existiert bereits ein bestehendes HTML-Gerüst, das bisher manuell für eBay-Beschreibungen verwendet wurde.
+
+Dieses Template ist für den MVP gut geeignet, weil es:
+
+- klar strukturiert ist
+- leicht lesbar ist
+- typische Angebotsdaten bereits sinnvoll gliedert
+- mit wenig Aufwand automatisiert befüllt werden kann
+
+Gleichzeitig muss das System damit umgehen können, dass manche Informationen nicht immer vorhanden sind, z. B.:
+
+- kein Kaufdatum
+- keine EAN
+- nur alternative Produktkennungen
+- überhaupt keine Produktkennung
+
+## Entscheidung
+
+Das bestehende HTML-Gerüst wird als Grundlage übernommen und technisch in ein platzhalterbasiertes Template überführt.
+
+Wichtige Felder werden als Platzhalter modelliert.
+Pflichtfelder bleiben bewusst knapp, optionale Felder müssen sauber ausgelassen werden können.
+
+## Grundprinzipien
+
+- Template-Struktur bleibt nah am bestehenden HTML
+- Platzhalter werden serverseitig befüllt
+- optionale Felder dürfen vollständig fehlen
+- leere Abschnitte sollen im finalen HTML nicht unschön erscheinen
+
+## Unterstützte Platzhalter (erste Version)
+
+### Basisfelder
+
+- `manufacturer`
+- `product_name`
+- `condition`
+- `description_html`
+- `included_items_html`
+
+### Optionale Felder
+
+- `purchase_date`
+- `product_identifier_type`
+- `product_identifier_value`
+
+## Produktkennung bewusst flexibel
+
+Statt nur `ean` fest zu modellieren, wird eine allgemeinere Struktur verwendet.
+
+Beispiele:
+- EAN
+- GTIN
+- MPN
+- Hersteller-Teilenummer
+- interne Kennung
+
+Oder auch:
+- keine Kennung vorhanden
+
+## Beispiel für Template-Logik
+
+### Anzeige nur wenn vorhanden
+
+Wenn `purchase_date` fehlt:
+- Kaufdatum-Zeile nicht anzeigen
+
+Wenn keine Produktkennung vorhanden ist:
+- Kennungs-Zeile nicht anzeigen
+
+Wenn Kennung vorhanden ist:
+- Label dynamisch aus `product_identifier_type`
+- Wert aus `product_identifier_value`
+
+## Beispielhafte Template-Felder
+
+```text
+{{ manufacturer }}
+{{ product_name }}
+{{ condition }}
+{{ description_html }}
+{{ included_items_html }}
+{{ purchase_date }}
+{{ product_identifier_type }}
+{{ product_identifier_value }}
+```
+
+## Rendering-Regeln
+
+### Regel 1
+
+Pflichtnahe Felder wie Hersteller/Produkt/Zustand/Beschreibung sollen möglichst immer vorhanden sein oder im Review explizit bestätigt werden.
+
+### Regel 2
+
+Optionale Felder dürfen fehlen, ohne dass das Template kaputt aussieht.
+
+### Regel 3
+
+Listen wie Lieferumfang werden bereits als HTML-Fragment oder sicher renderbare Mehrzeilenstruktur vorbereitet.
+
+## Warum diese Entscheidung?
+
+### Vorteile
+
+- nah am bereits genutzten Template
+- keine Übermodellierung
+- auch für unscharfe / generische Artikel geeignet
+- funktioniert sowohl für Technikprodukte als auch für Alltagsgegenstände
+
+### Nachteile
+
+- Template-Rendering braucht etwas Logik für optionale Abschnitte
+- freie Beschreibungen müssen sauber normalisiert werden
+
+## Nicht gewählt
+
+### Stark starres Produktschema
+
+Nicht gewählt, weil viele Verkaufsartikel keine sauberen Produktnummern oder Kaufdaten haben.
+
+### Nur EAN als einziges Identifikationsfeld
+
+Nicht gewählt, weil das in der Praxis zu eng wäre.
+
+## Konsequenzen
+
+- Kaufdatum ist optional
+- Produktkennungen sind optional und typisiert
+- auch Artikel ohne Kennung müssen vollständig unterstützt werden
+- das Template-System muss bedingte Abschnitte sauber rendern können
+
+## Nächster Schritt
+
+Als Nächstes sollte definiert werden:
+
+1. wie die Review-Seite mit fehlenden Feldern umgeht
+2. wie Template-Blöcke technisch bedingt ein-/ausgeblendet werden

--- a/docs/adr/0005-review-validation-rules.md
+++ b/docs/adr/0005-review-validation-rules.md
@@ -1,0 +1,172 @@
+# ADR 0005 – Review and Validation Rules
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto erzeugt im MVP aus Bildern und wenigen Zusatzinfos zunächst nur einen Entwurf.
+
+Vor einer eBay-Draft-Erstellung muss der Nutzer den Entwurf prüfen können.
+Dabei ist wichtig:
+
+- nicht alle Daten sind immer verfügbar
+- fehlende Daten dürfen den Flow nicht unnötig blockieren
+- gleichzeitig sollen wesentliche Angaben nicht stillschweigend fehlen
+
+Deshalb braucht das Projekt klare Regeln:
+
+- welche Felder im Review besonders wichtig sind
+- welche Felder optional bleiben
+- wann ein Entwurf als ausreichend vollständig gilt
+- wann der Nutzer aktiv bestätigen oder ergänzen muss
+
+## Entscheidung
+
+Open Inserto verwendet im MVP drei Feldklassen:
+
+1. **wichtige Kernfelder**
+2. **optionale Komfortfelder**
+3. **kontextabhängige Felder**
+
+Ein Draft darf nur dann in den Marketplace-Schritt übergehen, wenn die wichtigen Kernfelder vorhanden oder vom Nutzer bewusst bestätigt wurden.
+
+## 1. Wichtige Kernfelder
+
+Diese Felder sollen möglichst vorhanden sein:
+
+- `product_name`
+- `condition`
+- `description_html`
+- `included_items_html`
+
+Zusätzlich meist wichtig, aber nicht absolut technisch erzwungen:
+
+- `manufacturer`
+
+### Regel
+
+Wenn eines dieser Felder leer oder offensichtlich unsicher ist, soll die Review-Seite dies sichtbar markieren.
+Der Nutzer muss dann:
+
+- den Wert ergänzen
+- den Vorschlag korrigieren
+- oder bewusst bestätigen, dass der Entwurf trotzdem so verwendet werden soll
+
+## 2. Optionale Komfortfelder
+
+Diese Felder dürfen fehlen, ohne den Flow zu blockieren:
+
+- `purchase_date`
+- `product_identifier_type`
+- `product_identifier_value`
+- `subtitle`
+- feinere Attributfelder
+
+### Regel
+
+Diese Felder werden angezeigt, wenn vorhanden.
+Fehlen sie, darf der Entwurf trotzdem weiterverwendet werden.
+
+## 3. Kontextabhängige Felder
+
+Manche Felder sind nur in bestimmten Situationen sinnvoll oder relevant, z. B.:
+
+- Marke bei No-Name-Artikeln
+- Produktkennung bei Einzelstücken
+- genaue technische Merkmale bei Elektronik
+
+### Regel
+
+Diese Felder werden nicht global erzwungen.
+Die App darf sie empfehlen oder hervorheben, aber nicht pauschal blockieren.
+
+## Review-Regeln im MVP
+
+### Regel 1 – Sichtbare Unsicherheiten
+
+Wenn das System einen Wert nur mit geringer Sicherheit erkannt hat, soll das Feld als unsicher markiert werden.
+
+### Regel 2 – Kein stilles Leerräumen
+
+Wichtige Felder dürfen nicht unbemerkt leer bleiben.
+
+### Regel 3 – Nutzerentscheidung zählt
+
+Wenn der Nutzer einen unvollständigen, aber trotzdem ausreichend guten Entwurf bewusst bestätigt, darf der Flow weitergehen.
+
+### Regel 4 – Optionale Felder blockieren nicht
+
+Fehlende Kaufdaten oder fehlende Produktkennungen stoppen den Flow nicht.
+
+## Praktisches Verhalten der Review-Seite
+
+Die Review-Seite soll pro Feld oder Feldgruppe anzeigen:
+
+- aktueller Wert
+- Unsicherheits-/Fehlhinweis
+- Bearbeitungsmöglichkeit
+
+Zusätzlich soll es eine kompakte Zusammenfassung geben:
+
+- `ready`
+- `needs_attention`
+- `blocked`
+
+## Beispielhafte Bewertung
+
+### `ready`
+
+- alle Kernfelder vorhanden oder bestätigt
+- keine gravierenden Unklarheiten
+
+### `needs_attention`
+
+- einzelne wichtige Felder unsicher oder leer
+- Nutzer kann aber direkt nacharbeiten oder bewusst bestätigen
+
+### `blocked`
+
+- Entwurf technisch oder fachlich zu unklar
+- z. B. Produktart nicht sinnvoll erkennbar
+- Beschreibung unbrauchbar
+- Bilder reichen offensichtlich nicht aus
+
+## Warum diese Entscheidung?
+
+### Vorteile
+
+- praxistauglich
+- kein unnötig starres Pflichtschema
+- trotzdem Qualitätskontrolle vor externer Aktion
+- funktioniert auch für ungewöhnliche Artikel
+
+### Nachteile
+
+- etwas mehr Review-Logik nötig
+- Nutzer muss gelegentlich bewusst entscheiden statt nur durchzuklicken
+
+## Nicht gewählt
+
+### Starres Pflichtfeldschema für alle Artikel
+
+Nicht gewählt, weil viele Alltagsartikel und Einzelstücke damit unnötig blockiert würden.
+
+### Vollautomatische Freigabe ohne Review
+
+Nicht gewählt, weil das zu Beginn zu riskant ist.
+
+## Konsequenzen
+
+- die Review-Seite wird ein zentraler Bestandteil des MVP
+- Kernfelder werden hervorgehoben
+- optionale Felder bleiben optional
+- Nutzerbestätigung ist im Zweifelsfall wichtiger als technische Vollständigkeit
+
+## Nächster Schritt
+
+Als Nächstes sollte festgelegt werden:
+
+1. wie eBay-Daten aus dem internen Modell gemappt werden
+2. welche eBay-Felder für den ersten Draft-Workflow minimal nötig sind

--- a/docs/adr/0006-ebay-draft-mapping.md
+++ b/docs/adr/0006-ebay-draft-mapping.md
@@ -1,0 +1,132 @@
+# ADR 0006 – Minimal eBay Mapping for the Draft Workflow
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto soll im MVP einen sicheren eBay-Draft-Workflow unterstützen.
+
+Dabei geht es **nicht** darum, sofort alle eBay-Details vollständig zu automatisieren, sondern einen belastbaren ersten Draft-Prozess zu schaffen.
+
+Ziel:
+
+- interne Draft-Daten erzeugen
+- daraus die minimal nötigen eBay-Felder ableiten
+- einen nicht veröffentlichten eBay-Entwurf vorbereiten
+- manuelle Prüfung vor Live-Schaltung ermöglichen
+
+## Entscheidung
+
+Im MVP wird das interne Listing-Modell nur auf die **minimal nötigen eBay-Felder** abgebildet, die für einen ersten unveröffentlichten Offer-Workflow sinnvoll sind.
+
+Komplexere Themen wie erweiterte Kategorieattribute, Varianten, Geschäftsregeln oder internationale Versandlogik werden zunächst zurückgestellt.
+
+## Zielobjekte in eBay
+
+Der MVP soll mit der Sell Inventory API arbeiten und dabei im Kern diese Objekte nutzen:
+
+1. **Inventory Item**
+2. **Offer**
+3. **Publish** erst später / optional
+
+## Minimale Mapping-Felder
+
+### A. Inventory-Item-nahe Daten
+
+Aus dem internen Modell sollen für eBay mindestens ableitbar sein:
+
+- `sku` / interner eindeutiger Schlüssel
+- `title`
+- `description` (HTML)
+- `condition`
+- `product`-nahe Informationen, soweit sinnvoll vorhanden
+- Bildreferenzen
+
+### B. Offer-nahe Daten
+
+Für den ersten Offer-Entwurf sollen mindestens ableitbar sein:
+
+- Marketplace / Site
+- Format / Listing-Typ (z. B. Festpreis oder Auktion – zunächst zu entscheiden)
+- Preis oder Startpreis
+- verfügbare Menge
+- Kategorie
+- Versand-/Fulfillment-Profil
+- Zahlungs-/Policy-Referenzen
+- Return-/Policy-Referenzen
+
+## Interne zu externe Feldzuordnung (erste Version)
+
+### Interne Felder
+
+- `listing.title` -> eBay Title
+- `listing.descriptionHtml` -> eBay Description
+- `listing.condition` -> eBay Condition
+- `listing.categorySuggestion` -> eBay Category / Category Proposal
+- `source.images` / normalisierte Bilddaten -> eBay Image URLs
+- `listing.priceSuggestion` -> eBay Price / Start Price
+- `listing.includedItems` -> Teil der Beschreibung, nicht als separates eBay-Kernfeld
+- `listing.attributes` -> zunächst optional / nur bei Bedarf
+
+### Interne Workflow-Felder
+
+- `workflow.status` steuert, ob ein eBay-Offer überhaupt erzeugt werden darf
+- `marketplace.ebay.inventoryItemKey` speichert eBay-Bezug
+- `marketplace.ebay.offerId` speichert den unveröffentlichten Offer
+
+## Was im MVP noch **nicht** zwingend automatisiert werden muss
+
+Diese Themen dürfen zunächst bewusst vereinfacht oder manuell gehalten werden:
+
+- komplexe Kategorie-Merkmale
+- Variantenprodukte
+- erweiterte Item Specifics
+- differenzierte internationale Versandregeln
+- Mehrmengenlogik
+- mehrere Marktplätze parallel
+
+## Minimaler technischer Zielzustand
+
+Ein Draft gilt als MVP-seitig erfolgreich, wenn:
+
+1. ein internes Draft-Modell vollständig genug ist
+2. daraus ein eBay Inventory Item erzeugt/aktualisiert werden kann
+3. daraus ein unveröffentlichter Offer erzeugt werden kann
+4. die externe Offer-ID lokal gespeichert wird
+
+## Warum diese Entscheidung?
+
+### Vorteile
+
+- schneller MVP
+- weniger API-Komplexität
+- konzentriert sich auf den wertstiftenden Kern
+- reduziert Risiko bei externer Marktplatz-Integration
+
+### Nachteile
+
+- manche eBay-spezifischen Optimierungen fehlen zunächst
+- bestimmte Produktklassen brauchen später zusätzliche Felder
+
+## Nicht gewählt
+
+### Vollständiges eBay-Mapping von Anfang an
+
+Nicht gewählt, weil das zu viel Komplexität in den MVP bringen würde.
+
+### Reine HTML-/Text-Automation ohne echtes Mapping
+
+Nicht gewählt, weil das keinen sauberen API-Weg für echte Drafts schaffen würde.
+
+## Offene Folgeentscheidungen
+
+Auf Basis dieses ADR sollten als Nächstes geklärt werden:
+
+1. welches Listing-Format im MVP zuerst unterstützt wird
+   - Festpreis
+   - Auktion
+2. wie SKU/IDs intern generiert werden
+3. wie Bildhosting / Bild-URLs für eBay gehandhabt werden
+4. welche eBay-Policies im Setup vorausgesetzt werden

--- a/docs/adr/0007-initial-listing-format.md
+++ b/docs/adr/0007-initial-listing-format.md
@@ -1,0 +1,114 @@
+# ADR 0007 – Initial Listing Format for the MVP
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto soll im MVP erstmals echte eBay-Drafts erzeugen.
+
+Dafür muss festgelegt werden, welches Listing-Format als erstes unterstützt wird.
+
+Grundsätzlich kommen vor allem zwei Richtungen in Frage:
+
+- **Auktion**
+- **Festpreis / Buy It Now**
+
+Da das Tool später erweitert werden kann, muss im MVP nicht sofort alles gleichzeitig unterstützt werden.
+
+## Entscheidung
+
+Im MVP wird zunächst **ein einziges primäres Listing-Format** unterstützt:
+
+- **Festpreis / Buy It Now**
+
+Auktions-Listings werden zunächst nicht als erster Standardfall umgesetzt.
+
+## Warum Festpreis zuerst?
+
+### 1. API- und Prozesslogik ist einfacher
+
+Festpreis-Listings sind im Draft-/Offer-Modell meist einfacher zu behandeln als Auktionslogik mit:
+
+- Startpreis
+- Laufzeit
+- Bietdynamik
+- Endzeitpunkt
+
+### 2. Besserer Fit für einen Draft-Workflow
+
+Für einen ersten Review- und Draft-Prozess ist Festpreis oft einfacher:
+
+- Preisvorschlag erzeugen
+- Entwurf prüfen
+- Offer anlegen
+- später optional veröffentlichen
+
+### 3. Geringeres Risiko im MVP
+
+Auktionen bringen mehr Marktplatz-Spezifika und potenziell mehr Fehlkonfigurationen mit.
+
+## Was heißt das konkret?
+
+Der erste MVP unterstützt:
+
+- genau einen Artikel
+- genau einen Preis
+- keine Varianten
+- kein Auktionsende
+- kein Bietverhalten
+
+## Spätere Erweiterung
+
+Auktionen sollen nicht ausgeschlossen werden.
+Sie werden nur **nicht als erste Ausbaustufe** umgesetzt.
+
+Mögliche spätere Erweiterung:
+
+- `listingFormat = fixed_price`
+- `listingFormat = auction`
+
+## Konsequenzen für das Datenmodell
+
+Für den MVP reicht zunächst:
+
+- `priceSuggestion`
+- ggf. später `listingFormat`
+
+Noch nicht nötig im MVP:
+
+- `auctionStartPrice`
+- `auctionDuration`
+- `reservePrice`
+- `buyItNowPrice` bei Auktionsmodellen
+
+## Vorteile
+
+- schnellerer MVP
+- einfacher zu testen
+- klarerer erster API-Weg
+- weniger eBay-spezifische Sonderlogik
+
+## Nachteile
+
+- erste Version deckt nicht alle realen Verkaufsfälle ab
+- Nutzer, die primär Auktionen wollen, müssen auf spätere Erweiterung warten
+
+## Nicht gewählt
+
+### Direkt Auktion zuerst
+
+Nicht gewählt, weil es für den MVP unnötig komplexer ist.
+
+### Beides gleichzeitig
+
+Nicht gewählt, weil das zu früh zu viele Pfade und Sonderfälle erzeugen würde.
+
+## Nächster Schritt
+
+Als Nächstes sollte geklärt werden:
+
+1. wie interne SKUs / Draft-IDs erzeugt werden
+2. wie Bilder technisch gespeichert und später an eBay übergeben werden
+3. welche minimalen eBay-Policies beim Setup vorausgesetzt werden

--- a/docs/adr/0008-draft-ids-and-image-storage.md
+++ b/docs/adr/0008-draft-ids-and-image-storage.md
@@ -1,0 +1,166 @@
+# ADR 0008 – Draft IDs, SKUs and Image Storage
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto benötigt für den MVP eine saubere Strategie für:
+
+- interne Draft-IDs
+- eBay-/Marketplace-SKUs
+- Bildspeicherung
+- Bildreferenzen innerhalb des Draft-Modells
+
+Diese Entscheidungen sind wichtig, weil Drafts später:
+
+- erneut geöffnet
+- bearbeitet
+- an eBay übergeben
+- und ggf. mit externen IDs verknüpft werden sollen
+
+## Entscheidung
+
+Für den MVP wird zwischen **interner Draft-ID** und **Marketplace-SKU** unterschieden.
+
+Zusätzlich werden hochgeladene Bilder lokal in einer strukturierten Dateispeicherung abgelegt und im Draft-Modell referenziert.
+
+## 1. Interne Draft-ID
+
+Jeder Draft erhält eine interne, systemeigene ID.
+
+### Format
+
+Beispiel:
+
+```text
+draft_20260410_ab12cd34
+```
+
+### Eigenschaften
+
+- eindeutig
+- unabhängig von eBay
+- stabil über den gesamten Draft-Lebenszyklus
+- geeignet für URLs, Datenbankeinträge und Dateipfade
+
+## 2. Marketplace-SKU
+
+Für eBay wird zusätzlich eine SKU benötigt.
+
+### Grundsatz
+
+Die SKU darf von der internen Draft-ID abgeleitet werden, sollte aber als eigener Wert behandelt werden.
+
+### Beispiel
+
+```text
+oi-draft-20260410-ab12cd34
+```
+
+### Warum getrennt?
+
+- interne IDs bleiben systemintern
+- SKU bleibt marktplatzorientiert
+- spätere Plattformen können eigene externe Kennungslogik bekommen
+
+## 3. Bildspeicherung
+
+Bilder werden im MVP lokal in der Anwendung gespeichert.
+
+### Ziel
+
+- einfacher Betrieb im Docker-/NAS-Setup
+- stabile Referenzen pro Draft
+- keine externe Bildabhängigkeit im ersten Schritt
+
+### Vorgeschlagene Struktur
+
+```text
+/storage
+  /drafts
+    /draft_20260410_ab12cd34
+      /images
+        01-original.jpg
+        02-original.jpg
+        03-processed.jpg
+```
+
+## 4. Bildreferenzen im Draft-Modell
+
+Im `source.images`-Block sollen Bilddaten strukturiert referenziert werden.
+
+### Beispiel
+
+```json
+[
+  {
+    "id": "img_01",
+    "originalFilename": "IMG_1234.jpg",
+    "storagePath": "/storage/drafts/draft_20260410_ab12cd34/images/01-original.jpg",
+    "mimeType": "image/jpeg",
+    "order": 1,
+    "kind": "original"
+  }
+]
+```
+
+## 5. Reihenfolge der Bilder
+
+Die Reihenfolge soll explizit gespeichert werden.
+
+### Warum?
+
+- Hauptbild ist wichtig
+- eBay-Bildreihenfolge muss reproduzierbar sein
+- Nutzer soll Reihenfolge später anpassen können
+
+## 6. Spätere Bildverarbeitung
+
+Im MVP dürfen Bilder zunächst einfach nur gespeichert werden.
+
+Spätere Erweiterungen könnten umfassen:
+
+- verkleinerte Vorschaubilder
+- Metadaten-Extraktion
+- Duplikaterkennung
+- einfache Bildoptimierung
+
+## 7. Warum lokale Speicherung zuerst?
+
+### Vorteile
+
+- einfach im MVP
+- keine zusätzliche Cloud-/Object-Storage-Abhängigkeit
+- leicht auf NAS/Docker betreibbar
+
+### Nachteile
+
+- spätere Skalierung begrenzt
+- Veröffentlichung an Marktplätze braucht später saubere Bild-Übergabe
+
+## Nicht gewählt
+
+### Nur eBay-IDs als Primärreferenz
+
+Nicht gewählt, weil Drafts auch vor eBay-Integration stabil identifizierbar sein müssen.
+
+### Externe Bildspeicherung von Anfang an
+
+Nicht gewählt, weil das für den MVP unnötig komplex wäre.
+
+## Konsequenzen
+
+- jeder Draft bekommt eine stabile interne ID
+- eBay bekommt eine getrennte SKU
+- Bilder liegen lokal pro Draft in eigener Struktur
+- Bildreihenfolge wird explizit gespeichert
+
+## Nächster Schritt
+
+Als Nächstes sollte geklärt werden:
+
+1. wie eBay-Auth und Tokenverwaltung erfolgen
+2. wie Bild-Uploads technisch an eBay übergeben werden
+3. welche lokalen Statusübergänge beim Erstellen eines Offers gelten

--- a/docs/adr/0009-ebay-auth-and-token-management.md
+++ b/docs/adr/0009-ebay-auth-and-token-management.md
@@ -1,0 +1,146 @@
+# ADR 0009 – eBay Auth and Token Management
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto soll im MVP eBay-Drafts über die Sell Inventory API vorbereiten.
+
+Dafür braucht die Anwendung:
+
+- einen sicheren Authentifizierungsweg zu eBay
+- eine praktikable Tokenverwaltung
+- einen Weg, lokale Entwicklung und produktiven Betrieb zu trennen
+
+Gerade bei Verkaufsplattformen ist wichtig:
+
+- keine Secrets im Code
+- klare Trennung zwischen Konfiguration und Anwendung
+- Tokens und Refresh-Mechanismen sauber handhaben
+
+## Entscheidung
+
+Im MVP wird eBay über OAuth angebunden.
+
+Zugangsdaten und Tokens werden:
+
+- **nicht im Code** gespeichert
+- **nicht in Git** gespeichert
+- über Umgebungsvariablen und sichere Laufzeitkonfiguration bereitgestellt
+
+## Grundprinzipien
+
+- eBay App-Credentials liegen in der Laufzeitumgebung
+- Access Tokens werden zur Laufzeit verwendet
+- Refresh-Mechanismen werden vorbereitet
+- produktive Secrets gehören in `.env` / Container-Umgebung / Secret-Management, nicht ins Repo
+
+## MVP-Ansatz
+
+### Benötigte Konfigurationswerte
+
+Voraussichtlich u. a.:
+
+- eBay Client ID
+- eBay Client Secret
+- Redirect URI / RuName
+- Marketplace / Site-Konfiguration
+- Access Token
+- ggf. Refresh Token
+
+### Speicherung
+
+Für den MVP bevorzugt:
+
+- `.env` für lokale Entwicklung
+- Docker-Umgebungsvariablen für Containerbetrieb
+
+Optional später:
+- Secret Store / Vault / NAS-spezifisches Secret-Management
+
+## Was nicht ins Repo darf
+
+- Client Secret
+- Access Tokens
+- Refresh Tokens
+- Session-Daten
+- Account-spezifische Live-Credentials
+
+## Trennung der Umgebungen
+
+Es soll zumindest logisch getrennt werden zwischen:
+
+- **Sandbox / Test**
+- **Live / Produktion**
+
+### Warum?
+
+- Draft-Workflow zuerst risikoarm testen
+- Live-Listings nicht versehentlich erzeugen
+- spätere Freigabe kontrollierbar machen
+
+## Token-Verhalten
+
+### Access Token
+
+- kurzlebig
+- zur Laufzeit nutzbar
+- nicht dauerhaft hart im Code abgelegt
+
+### Refresh Token
+
+- falls für den gewählten Flow nötig, besonders sensibel behandeln
+- nur lokal sicher speichern
+- nicht in Logs schreiben
+
+## Logging-Regeln
+
+Die Anwendung darf niemals loggen:
+
+- vollständige Tokens
+- Secrets
+- Authorization-Header
+- Client Secret
+
+Wenn Auth-Fehler auftreten, dann nur als technische Fehlermeldung ohne Secret-Leak.
+
+## Warum diese Entscheidung?
+
+### Vorteile
+
+- sauberer Sicherheitsstandard für den MVP
+- Docker/NAS-tauglich
+- später gut aufrüstbar
+- kein unnötiges Secret-Risiko im Repo
+
+### Nachteile
+
+- etwas mehr Setup-Aufwand am Anfang
+- eBay-OAuth-Flow muss sauber verstanden und getestet werden
+
+## Nicht gewählt
+
+### Credentials fest im Code
+
+Nicht gewählt, weil sicherheitstechnisch inakzeptabel.
+
+### Manuelle Token-Eingabe pro Request
+
+Nicht gewählt, weil unpraktisch und fehleranfällig.
+
+## Konsequenzen
+
+- das Projekt braucht früh eine saubere `.env`-Strategie
+- `.gitignore` muss Secrets ausschließen
+- produktive eBay-Zugangsdaten bleiben außerhalb des Repos
+- spätere OAuth-Implementierung muss als eigener technischer Baustein betrachtet werden
+
+## Nächster Schritt
+
+Als Nächstes sollte festgelegt werden:
+
+1. ob wir im MVP zuerst Sandbox oder direkt Live-Drafts ansteuern
+2. wie das lokale Review-Ergebnis in einen eBay-Offer-Erstellungsprozess überführt wird
+3. welche Statusübergänge intern nach erfolgreicher Offer-Erstellung gelten

--- a/docs/adr/0010-sandbox-vs-live-drafts.md
+++ b/docs/adr/0010-sandbox-vs-live-drafts.md
@@ -1,0 +1,105 @@
+# ADR 0010 – Sandbox vs. Live Draft Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Open Inserto soll eBay-Drafts erzeugen.
+
+Vor der produktiven Nutzung stellt sich die Frage:
+
+- erst in der eBay-Sandbox entwickeln und testen?
+- oder direkt mit Live-Drafts arbeiten?
+
+Beide Wege haben Vor- und Nachteile.
+
+## Entscheidung
+
+Für den MVP gilt folgende Strategie:
+
+1. **technische Entwicklung und erste API-Tests** möglichst gegen **Sandbox**, soweit sinnvoll
+2. **fachlich echter Draft-Workflow** anschließend mit **Live-Drafts**, weil nur dort der reale Verkäufer-Account und die echte spätere Veröffentlichung relevant sind
+
+## Warum nicht nur Sandbox?
+
+Die Sandbox ist sinnvoll für:
+
+- OAuth-/API-Grundtests
+- Payload-Struktur
+- technische Integrationsfehler
+
+Aber sie reicht oft nicht vollständig für den echten Nutzwert, weil:
+
+- reale Verkäuferkonfigurationen fehlen können
+- echte Policies / reale Konto-Setups abweichen können
+- der echte Draft- und Veröffentlichungsprozess im Live-Account entscheidend ist
+
+## Warum nicht nur Live?
+
+Nur Live wäre für den Start unnötig riskant.
+
+Deshalb:
+- technische Grundlagen zuerst möglichst risikoarm testen
+- danach gezielt auf Live-Drafts wechseln
+- Veröffentlichung weiterhin bewusst getrennt halten
+
+## Praktische MVP-Strategie
+
+### Phase 1 – technische API-Validierung
+
+- OAuth testen
+- Inventory-Item-Flow testen
+- Offer-Erstellung technisch testen
+- Fehlerfälle verstehen
+
+### Phase 2 – echter Draft-Workflow im Live-Account
+
+- nur unveröffentlichte Offers erzeugen
+- Review bleibt Pflicht
+- Veröffentlichung nicht automatisieren, solange der Draft-Prozess nicht stabil ist
+
+## Sicherheits- und Prozessgedanke
+
+Der wichtige Schutz liegt nicht nur in Sandbox vs. Live, sondern auch in:
+
+- Draft-first-Ansatz
+- manueller Review
+- keine automatische Veröffentlichung im MVP
+
+## Konsequenzen
+
+- die Anwendung sollte beide Modi grundsätzlich trennen können
+- Konfiguration für Sandbox und Live muss sauber getrennt sein
+- erste echte Nutzbarkeit entsteht über Live-Drafts
+- Veröffentlichung bleibt zunächst ein bewusster separater Schritt
+
+## Vorteile
+
+- risikoärmerer Start
+- realistischer Live-Nutzen bleibt möglich
+- bessere Kontrolle beim Übergang in echte Listings
+
+## Nachteile
+
+- zwei Umgebungen erhöhen den Integrationsaufwand
+- Sandbox kann nicht alle realen Bedingungen abbilden
+
+## Nicht gewählt
+
+### Nur Sandbox
+
+Nicht gewählt, weil der echte Mehrwert des Tools dann zu spät überprüfbar wäre.
+
+### Sofort voll auf Live ohne Vorprüfung
+
+Nicht gewählt, weil das unnötige Fehler- und Account-Risiken erzeugen würde.
+
+## Nächster Schritt
+
+Als Nächstes sollte festgelegt werden:
+
+1. welche internen Status ein Draft nach erfolgreicher Offer-Erstellung bekommt
+2. wie die App lokale Drafts und externe eBay-Offer-IDs zusammenführt
+3. wie die erste Review-/Statusseite nach erfolgreichem eBay-Draft aussehen soll

--- a/docs/adr/0011-status-transitions.md
+++ b/docs/adr/0011-status-transitions.md
@@ -1,0 +1,34 @@
+# ADR 0011 – Internal Status Transitions
+
+## Status
+Accepted
+
+## Decision
+The MVP uses explicit internal workflow states for each draft.
+
+## States
+- `draft`
+- `classified`
+- `needs_attention`
+- `ready_for_review`
+- `ready_for_marketplace`
+- `offer_created`
+- `published`
+- `blocked`
+- `error`
+
+## Transition examples
+- upload complete -> `draft`
+- first analysis complete -> `classified`
+- missing key information -> `needs_attention`
+- user confirms/corrects -> `ready_for_review`
+- review accepted -> `ready_for_marketplace`
+- eBay offer created -> `offer_created`
+- later publishing step -> `published`
+- unresolved blocker -> `blocked`
+- technical failure -> `error`
+
+## Why
+- clear UI state
+- retry-safe process handling
+- easier debugging and persistence

--- a/docs/adr/0011-status-transitions.md
+++ b/docs/adr/0011-status-transitions.md
@@ -1,12 +1,15 @@
-# ADR 0011 – Internal Status Transitions
+# ADR 0011 – Interne Statusübergänge
 
 ## Status
+
 Accepted
 
-## Decision
-The MVP uses explicit internal workflow states for each draft.
+## Entscheidung
 
-## States
+Der MVP verwendet explizite interne Workflow-Status für jeden Draft.
+
+## Statuswerte
+
 - `draft`
 - `classified`
 - `needs_attention`
@@ -17,18 +20,20 @@ The MVP uses explicit internal workflow states for each draft.
 - `blocked`
 - `error`
 
-## Transition examples
-- upload complete -> `draft`
-- first analysis complete -> `classified`
-- missing key information -> `needs_attention`
-- user confirms/corrects -> `ready_for_review`
-- review accepted -> `ready_for_marketplace`
-- eBay offer created -> `offer_created`
-- later publishing step -> `published`
-- unresolved blocker -> `blocked`
-- technical failure -> `error`
+## Beispielhafte Übergänge
 
-## Why
-- clear UI state
-- retry-safe process handling
-- easier debugging and persistence
+- Upload abgeschlossen -> `draft`
+- erste Analyse abgeschlossen -> `classified`
+- wichtige Informationen fehlen -> `needs_attention`
+- Nutzer bestätigt oder korrigiert -> `ready_for_review`
+- Review abgeschlossen -> `ready_for_marketplace`
+- eBay-Offer erfolgreich erstellt -> `offer_created`
+- spätere Veröffentlichung -> `published`
+- offener Blocker -> `blocked`
+- technischer Fehler -> `error`
+
+## Warum?
+
+- klarer UI-Zustand
+- sichere Wiederaufnahme bei Unterbrechungen
+- einfacheres Debugging und bessere Persistenz

--- a/docs/adr/0012-local-draft-to-ebay-linkage.md
+++ b/docs/adr/0012-local-draft-to-ebay-linkage.md
@@ -1,0 +1,23 @@
+# ADR 0012 – Local Draft to eBay Linkage
+
+## Status
+Accepted
+
+## Decision
+A local draft remains the system of record and stores the linkage to eBay objects.
+
+## Required stored linkage
+- internal `draft_id`
+- marketplace `sku`
+- `inventoryItemKey`
+- `offerId`
+- current local workflow state
+- timestamps of creation/update
+
+## Principle
+The local draft must remain usable even if eBay offer creation fails or has to be retried.
+
+## Why
+- stable recovery path
+- decouples local work from external API state
+- simplifies edits and retries

--- a/docs/adr/0012-local-draft-to-ebay-linkage.md
+++ b/docs/adr/0012-local-draft-to-ebay-linkage.md
@@ -1,23 +1,28 @@
-# ADR 0012 – Local Draft to eBay Linkage
+# ADR 0012 – Verknüpfung lokaler Drafts mit eBay
 
 ## Status
+
 Accepted
 
-## Decision
-A local draft remains the system of record and stores the linkage to eBay objects.
+## Entscheidung
 
-## Required stored linkage
-- internal `draft_id`
-- marketplace `sku`
+Der lokale Draft bleibt die führende interne Datenquelle und speichert die Verknüpfung zu eBay-Objekten.
+
+## Erforderliche Verknüpfungsdaten
+
+- interne `draft_id`
+- Marketplace-`sku`
 - `inventoryItemKey`
 - `offerId`
-- current local workflow state
-- timestamps of creation/update
+- aktueller lokaler Workflow-Status
+- Zeitstempel für Erstellung und letzte Aktualisierung
 
-## Principle
-The local draft must remain usable even if eBay offer creation fails or has to be retried.
+## Grundprinzip
 
-## Why
-- stable recovery path
-- decouples local work from external API state
-- simplifies edits and retries
+Der lokale Draft muss auch dann nutzbar bleiben, wenn die eBay-Offer-Erstellung fehlschlägt oder erneut versucht werden muss.
+
+## Warum?
+
+- stabiler Wiederaufnahmepfad
+- Trennung zwischen lokaler Arbeit und externem API-Zustand
+- einfachere Bearbeitung und Retries

--- a/docs/adr/0013-result-and-status-page.md
+++ b/docs/adr/0013-result-and-status-page.md
@@ -1,0 +1,22 @@
+# ADR 0013 – Result and Status Page
+
+## Status
+Accepted
+
+## Decision
+After draft creation or eBay offer creation, the app shows a simple status/result page.
+
+## MVP contents
+- draft title
+- internal draft id
+- current workflow status
+- whether review is still needed
+- eBay inventory item key (if available)
+- eBay offer id (if available)
+- last action result
+- next recommended action
+
+## Why
+- keeps the app understandable
+- avoids hidden background state
+- makes manual review easy

--- a/docs/adr/0013-result-and-status-page.md
+++ b/docs/adr/0013-result-and-status-page.md
@@ -1,22 +1,26 @@
-# ADR 0013 – Result and Status Page
+# ADR 0013 – Ergebnis- und Statusseite
 
 ## Status
+
 Accepted
 
-## Decision
-After draft creation or eBay offer creation, the app shows a simple status/result page.
+## Entscheidung
 
-## MVP contents
-- draft title
-- internal draft id
-- current workflow status
-- whether review is still needed
-- eBay inventory item key (if available)
-- eBay offer id (if available)
-- last action result
-- next recommended action
+Nach der Draft-Erstellung oder der eBay-Offer-Erstellung zeigt die App eine einfache Status-/Ergebnis-Seite an.
 
-## Why
-- keeps the app understandable
-- avoids hidden background state
-- makes manual review easy
+## Inhalte im MVP
+
+- Draft-Titel
+- interne Draft-ID
+- aktueller Workflow-Status
+- ob noch Review nötig ist
+- eBay Inventory Item Key (falls vorhanden)
+- eBay Offer ID (falls vorhanden)
+- Ergebnis der letzten Aktion
+- nächster empfohlener Schritt
+
+## Warum?
+
+- macht den Zustand der App verständlich
+- vermeidet versteckten Hintergrundzustand
+- erleichtert die manuelle Prüfung

--- a/docs/adr/0014-error-and-retry-strategy.md
+++ b/docs/adr/0014-error-and-retry-strategy.md
@@ -1,0 +1,26 @@
+# ADR 0014 – Error and Retry Strategy
+
+## Status
+Accepted
+
+## Decision
+The MVP must preserve local draft state on failure and allow safe retries.
+
+## Rules
+- never lose the local draft on API failure
+- store failure as local state
+- show actionable error messages
+- allow retry for marketplace creation
+- separate validation errors from external API errors
+
+## Example categories
+- input/validation error
+- template rendering error
+- image processing/storage error
+- eBay auth error
+- eBay API request error
+
+## Why
+- reliability over silent failure
+- better UX
+- easier debugging

--- a/docs/adr/0014-error-and-retry-strategy.md
+++ b/docs/adr/0014-error-and-retry-strategy.md
@@ -1,26 +1,31 @@
-# ADR 0014 – Error and Retry Strategy
+# ADR 0014 – Fehler- und Retry-Strategie
 
 ## Status
+
 Accepted
 
-## Decision
-The MVP must preserve local draft state on failure and allow safe retries.
+## Entscheidung
 
-## Rules
-- never lose the local draft on API failure
-- store failure as local state
-- show actionable error messages
-- allow retry for marketplace creation
-- separate validation errors from external API errors
+Der MVP muss den lokalen Draft-Zustand bei Fehlern erhalten und sichere Wiederholungen ermöglichen.
 
-## Example categories
-- input/validation error
-- template rendering error
-- image processing/storage error
-- eBay auth error
-- eBay API request error
+## Regeln
 
-## Why
-- reliability over silent failure
-- better UX
-- easier debugging
+- lokaler Draft darf bei API-Fehlern nie verloren gehen
+- Fehler werden als lokaler Zustand gespeichert
+- Fehlermeldungen sollen verständlich und handlungsorientiert sein
+- Marketplace-Erstellung muss erneut versucht werden können
+- Validierungsfehler und externe API-Fehler werden getrennt behandelt
+
+## Beispielhafte Fehlerkategorien
+
+- Eingabe-/Validierungsfehler
+- Template-Rendering-Fehler
+- Bildverarbeitungs-/Speicherfehler
+- eBay-Auth-Fehler
+- eBay-API-Fehler
+
+## Warum?
+
+- Zuverlässigkeit statt stiller Fehler
+- bessere Nutzerführung
+- einfachere Fehlersuche

--- a/docs/adr/0015-mvp-scope-and-non-goals.md
+++ b/docs/adr/0015-mvp-scope-and-non-goals.md
@@ -1,28 +1,33 @@
-# ADR 0015 – MVP Scope and Non-Goals
+# ADR 0015 – MVP-Umfang und Nicht-Ziele
 
 ## Status
+
 Accepted
 
-## MVP scope
-The first version should support:
-- single-item listing flow
-- image upload
-- structured draft generation
-- HTML template rendering
-- review step
-- eBay inventory item creation
-- unpublished eBay offer creation
-- local persistence of draft + external ids
+## MVP-Umfang
 
-## Explicit non-goals for MVP
-- automatic publication without review
-- auction support as first-class path
-- multi-marketplace support
-- variants
-- advanced shipping matrix logic
-- complex item specifics coverage for all categories
-- heavy SPA frontend
-- multi-user collaboration
+Die erste Version soll unterstützen:
 
-## Why
-A narrow MVP reduces risk and gets the useful core running earlier.
+- Single-Item-Listing-Flow
+- Bildupload
+- strukturierte Draft-Erzeugung
+- HTML-Template-Rendering
+- Review-Schritt
+- eBay Inventory Item Erstellung
+- unveröffentlichte eBay-Offer-Erstellung
+- lokale Persistenz von Draft + externen IDs
+
+## Explizite Nicht-Ziele für den MVP
+
+- automatische Veröffentlichung ohne Review
+- Auktionssupport als primärer Pfad
+- Multi-Marketplace-Support
+- Variantenprodukte
+- komplexe Versandmatrix-Logik
+- vollständige Abdeckung aller eBay-Item-Specifics
+- schwergewichtiges SPA-Frontend
+- Multi-User-Collaboration
+
+## Warum?
+
+Ein enger MVP reduziert Risiko und bringt den nützlichen Kern schneller zum Laufen.

--- a/docs/adr/0015-mvp-scope-and-non-goals.md
+++ b/docs/adr/0015-mvp-scope-and-non-goals.md
@@ -1,0 +1,28 @@
+# ADR 0015 – MVP Scope and Non-Goals
+
+## Status
+Accepted
+
+## MVP scope
+The first version should support:
+- single-item listing flow
+- image upload
+- structured draft generation
+- HTML template rendering
+- review step
+- eBay inventory item creation
+- unpublished eBay offer creation
+- local persistence of draft + external ids
+
+## Explicit non-goals for MVP
+- automatic publication without review
+- auction support as first-class path
+- multi-marketplace support
+- variants
+- advanced shipping matrix logic
+- complex item specifics coverage for all categories
+- heavy SPA frontend
+- multi-user collaboration
+
+## Why
+A narrow MVP reduces risk and gets the useful core running earlier.


### PR DESCRIPTION
Adds the initial Open Inserto planning foundation: README, implementation plan, and ADRs for stack, data model, review flow, template strategy, eBay draft mapping, auth, status model, retries, and MVP scope.