### PR TITLE
feat: scaffold FastAPI MVP foundation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+__pycache__/
+.pytest_cache/
+.venv/
+.env
+*.db

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+APP_NAME=Open Inserto
+APP_ENV=development
+APP_HOST=0.0.0.0
+APP_PORT=8000
+APP_DEBUG=true
+DATABASE_URL=sqlite:///data/open_inserto.db
+EBAY_MODE=sandbox
+EBAY_MARKETPLACE_ID=EBAY_DE
+EBAY_CLIENT_ID=your-ebay-client-id
+EBAY_CLIENT_SECRET=your-ebay-client-secret
+EBAY_RU_NAME=your-ebay-runame
+EBAY_ACCESS_TOKEN=
+EBAY_REFRESH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+.env
+.env.*
+!.env.example
+*.db
+data/*.db
+.tmp-gh-issue-bodies/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY .env.example ./.env.example
+COPY README.md ./README.md
+
+RUN mkdir -p /app/data
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    APP_HOST=0.0.0.0 \
+    APP_PORT=8000
 
 WORKDIR /app
 
@@ -16,4 +18,4 @@ RUN mkdir -p /app/data
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "uvicorn app.main:app --host ${APP_HOST:-0.0.0.0} --port ${APP_PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
-uvicorn app.main:app --reload
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 Dann ist die App unter <http://127.0.0.1:8000> erreichbar.
+
+Hinweis: Für Container- und Remote-Szenarien ist das explizite Host-Binding auf `0.0.0.0` wichtig, damit die Anwendung nicht nur innerhalb des Containers erreichbar ist.
 
 ## Tests
 
@@ -38,6 +40,8 @@ pytest
 docker build -t open-inserto .
 docker run --rm -p 8000:8000 --env-file .env -v $(pwd)/data:/app/data open-inserto
 ```
+
+Der Container nutzt standardmäßig `APP_HOST=0.0.0.0` und `APP_PORT=8000`. Bei Bedarf können die Werte über Umgebungsvariablen überschrieben werden.
 
 Alternativ mit Docker Compose:
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,35 @@ Das Projekt soll dabei helfen, aus Bildern und wenigen Zusatzinfos automatisch s
 - Angebotsdaten validieren
 - Entwürfe bei Plattformen wie eBay anlegen
 - später optional auch vollständige Veröffentlichungen unterstützen
+
+
+## MVP Scaffold lokal starten
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+uvicorn app.main:app --reload
+```
+
+Dann ist die App unter <http://127.0.0.1:8000> erreichbar.
+
+## Tests
+
+```bash
+pytest
+```
+
+## Docker
+
+```bash
+docker build -t open-inserto .
+docker run --rm -p 8000:8000 --env-file .env -v $(pwd)/data:/app/data open-inserto
+```
+
+Alternativ mit Docker Compose:
+
+```bash
+docker compose up --build
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Open Inserto application package."""

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application utilities."""

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,46 @@
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    app_name: str = "Open Inserto"
+    app_env: str = "development"
+    app_host: str = "0.0.0.0"
+    app_port: int = 8000
+    app_debug: bool = True
+
+    data_dir: Path = Path("data")
+    database_url: str = "sqlite:///data/open_inserto.db"
+
+    ebay_mode: str = Field(default="sandbox", pattern="^(sandbox|live)$")
+    ebay_marketplace_id: str = "EBAY_DE"
+    ebay_client_id: str | None = None
+    ebay_client_secret: str | None = None
+    ebay_ru_name: str | None = None
+    ebay_access_token: str | None = None
+    ebay_refresh_token: str | None = None
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    @property
+    def database_path(self) -> Path:
+        prefix = "sqlite:///"
+        if self.database_url.startswith(prefix):
+            return Path(self.database_url[len(prefix) :])
+        return Path(self.database_url)
+
+
+@lru_cache
+def get_settings() -> Settings:
+    settings = Settings()
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    settings.database_path.parent.mkdir(parents=True, exist_ok=True)
+    return settings

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database helpers."""

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,9 @@
+import sqlite3
+from pathlib import Path
+
+
+def get_connection(database_path: Path) -> sqlite3.Connection:
+    database_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(database_path)
+    connection.row_factory = sqlite3.Row
+    return connection

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from app.db.base import get_connection
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS app_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+def initialize_database(database_path: Path) -> None:
+    with get_connection(database_path) as connection:
+        connection.executescript(SCHEMA)
+        connection.execute(
+            """
+            INSERT INTO app_meta(key, value)
+            VALUES(?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            ("schema_version", "1"),
+        )
+        connection.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,30 @@
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from app.core.config import get_settings
+from app.db.init_db import initialize_database
+from app.web.routes import router as web_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_settings()
+    initialize_database(settings.database_path)
+    yield
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    app = FastAPI(
+        title=settings.app_name,
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+    app.include_router(web_router)
+    app.mount("/static", StaticFiles(directory="app/static"), name="static")
+    return app
+
+
+app = create_app()

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,0 +1,41 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  background: #f7f8fb;
+  color: #1c2434;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+}
+
+.hero {
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6a7282;
+  font-size: 0.8rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: white;
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{{ app_name }}{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='/css/app.css') }}">
+  </head>
+  <body>
+    <main class="container">
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} – MVP{% endblock %}
+
+{% block content %}
+<section class="hero">
+  <p class="eyebrow">MVP scaffold</p>
+  <h1>{{ app_name }}</h1>
+  <p>
+    FastAPI läuft, server-rendered Templates sind eingebunden und die SQLite-Basis
+    wurde vorbereitet.
+  </p>
+</section>
+
+<section class="card-grid">
+  <article class="card">
+    <h2>Konfiguration</h2>
+    <ul>
+      <li><strong>eBay-Modus:</strong> {{ ebay_mode }}</li>
+      <li><strong>Datenbank:</strong> {{ database_url }}</li>
+    </ul>
+  </article>
+
+  <article class="card">
+    <h2>Nächste Ausbaustufen</h2>
+    <ul>
+      <li>Bild-Upload</li>
+      <li>Draft-Datenmodell</li>
+      <li>eBay-Draft-Workflow</li>
+    </ul>
+  </article>
+</section>
+{% endblock %}

--- a/app/web/__init__.py
+++ b/app/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web routes and views."""

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app.core.config import get_settings
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    settings = get_settings()
+    return {
+        "status": "ok",
+        "environment": settings.app_env,
+        "ebay_mode": settings.ebay_mode,
+    }
+
+
+@router.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    settings = get_settings()
+    return templates.TemplateResponse(
+        request,
+        "index.html",
+        {
+            "app_name": settings.app_name,
+            "ebay_mode": settings.ebay_mode,
+            "database_url": settings.database_url,
+        },
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
 services:
   web:
     build: .
+    environment:
+      APP_HOST: ${APP_HOST:-0.0.0.0}
+      APP_PORT: ${APP_PORT:-8000}
     ports:
-      - "8000:8000"
+      - "${APP_PORT:-8000}:${APP_PORT:-8000}"
     env_file:
       - .env
     volumes:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.12
+uvicorn[standard]==0.34.0
+jinja2==3.1.6
+pydantic-settings==2.8.1
+pytest==8.3.5
+httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-fastapi==0.115.12
-uvicorn[standard]==0.34.0
+fastapi==0.135.3
+uvicorn[standard]==0.44.0
 jinja2==3.1.6
-pydantic-settings==2.8.1
-pytest==8.3.5
+pydantic-settings==2.13.1
+pytest==9.0.3
 httpx==0.28.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def test_health_endpoint():
+    client = TestClient(create_app())
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_index_page_renders():
+    client = TestClient(create_app())
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Open Inserto" in response.text
+    assert "MVP scaffold" in response.text


### PR DESCRIPTION
## Summary
- add a FastAPI application scaffold with central settings, health endpoint, templates and static assets
- prepare SQLite initialization plus local env/documentation for MVP setup
- add Docker assets and basic pytest coverage for the scaffold

## Testing
- pytest

## Notes
- Docker build could not be executed in this environment because the `docker` CLI is not installed here.

Closes #3
