### PR TITLE
fix: MVP draft model persistence and workflow status

### DIFF
--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -8,6 +8,23 @@ CREATE TABLE IF NOT EXISTS app_meta (
     value TEXT NOT NULL,
     updated_at TEXT DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS drafts (
+    id TEXT PRIMARY KEY,
+    sku TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL,
+    needs_review INTEGER NOT NULL,
+    marketplace_name TEXT NOT NULL DEFAULT 'ebay',
+    inventory_item_key TEXT,
+    offer_id TEXT,
+    data_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_drafts_status ON drafts(status);
+CREATE INDEX IF NOT EXISTS idx_drafts_sku ON drafts(sku);
+CREATE INDEX IF NOT EXISTS idx_drafts_offer_id ON drafts(offer_id);
 """
 
 
@@ -22,6 +39,6 @@ def initialize_database(database_path: Path) -> None:
                 value = excluded.value,
                 updated_at = CURRENT_TIMESTAMP
             """,
-            ("schema_version", "1"),
+            ("schema_version", "2"),
         )
         connection.commit()

--- a/app/drafts/__init__.py
+++ b/app/drafts/__init__.py
@@ -1,0 +1,13 @@
+from app.drafts.identity import derive_sku, generate_draft_id
+from app.drafts.models import Draft, WorkflowStatus
+from app.drafts.repository import DraftRepository
+from app.drafts.workflow import transition_draft
+
+__all__ = [
+    "Draft",
+    "DraftRepository",
+    "WorkflowStatus",
+    "derive_sku",
+    "generate_draft_id",
+    "transition_draft",
+]

--- a/app/drafts/identity.py
+++ b/app/drafts/identity.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from secrets import token_hex
+
+
+def generate_draft_id(now: datetime | None = None) -> str:
+    current = (now or datetime.now(UTC)).astimezone(UTC)
+    return f"draft_{current:%Y%m%d}_{token_hex(4)}"
+
+
+def derive_sku(draft_id: str) -> str:
+    prefix = "draft_"
+    if not draft_id.startswith(prefix):
+        msg = f"Unsupported draft ID format: {draft_id}"
+        raise ValueError(msg)
+
+    remainder = draft_id.removeprefix(prefix)
+    try:
+        date_part, suffix = remainder.split("_", 1)
+    except ValueError as exc:
+        msg = f"Unsupported draft ID format: {draft_id}"
+        raise ValueError(msg) from exc
+
+    return f"oi-draft-{date_part}-{suffix}"

--- a/app/drafts/models.py
+++ b/app/drafts/models.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class WorkflowStatus(StrEnum):
+    DRAFT = "draft"
+    CLASSIFIED = "classified"
+    NEEDS_ATTENTION = "needs_attention"
+    READY_FOR_REVIEW = "ready_for_review"
+    READY_FOR_MARKETPLACE = "ready_for_marketplace"
+    OFFER_CREATED = "offer_created"
+    PUBLISHED = "published"
+    BLOCKED = "blocked"
+    ERROR = "error"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class SourceImage(BaseModel):
+    id: str
+    original_filename: str = Field(alias="originalFilename")
+    storage_path: str = Field(alias="storagePath")
+    mime_type: str = Field(alias="mimeType")
+    order: int
+    kind: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SourceData(BaseModel):
+    images: list[SourceImage] = Field(default_factory=list)
+    notes: str = ""
+    user_input: dict[str, Any] = Field(default_factory=dict, alias="userInput")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ListingData(BaseModel):
+    title: str = ""
+    subtitle: str = ""
+    category_suggestion: str = Field(default="", alias="categorySuggestion")
+    condition: str = ""
+    brand: str = ""
+    model: str = ""
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    included_items: list[str] = Field(default_factory=list, alias="includedItems")
+    issues: list[str] = Field(default_factory=list)
+    description_html: str = Field(default="", alias="descriptionHtml")
+    price_suggestion: float | None = Field(default=None, alias="priceSuggestion")
+    shipping_suggestion: dict[str, Any] = Field(default_factory=dict, alias="shippingSuggestion")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class EbayDraftData(BaseModel):
+    inventory_item_data: dict[str, Any] = Field(default_factory=dict, alias="inventoryItemData")
+    offer_data: dict[str, Any] = Field(default_factory=dict, alias="offerData")
+    inventory_item_key: str | None = Field(default=None, alias="inventoryItemKey")
+    offer_id: str | None = Field(default=None, alias="offerId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MarketplaceData(BaseModel):
+    ebay: EbayDraftData = Field(default_factory=EbayDraftData)
+
+
+class WorkflowData(BaseModel):
+    status: WorkflowStatus = WorkflowStatus.DRAFT
+    needs_review: bool = Field(default=True, alias="needsReview")
+    missing_information: list[str] = Field(default_factory=list, alias="missingInformation")
+    last_updated_at: datetime = Field(default_factory=utc_now, alias="lastUpdatedAt")
+    created_at: datetime = Field(default_factory=utc_now, alias="createdAt")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class Draft(BaseModel):
+    id: str
+    sku: str
+    source: SourceData = Field(default_factory=SourceData)
+    listing: ListingData = Field(default_factory=ListingData)
+    marketplace: MarketplaceData = Field(default_factory=MarketplaceData)
+    workflow: WorkflowData = Field(default_factory=WorkflowData)
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/app/drafts/repository.py
+++ b/app/drafts/repository.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.db.base import get_connection
+from app.drafts.models import Draft, WorkflowStatus, utc_now
+
+
+class DraftRepository:
+    def __init__(self, database_path: Path):
+        self.database_path = database_path
+
+    def create_draft(self, draft: Draft) -> None:
+        with get_connection(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO drafts(
+                    id, sku, status, needs_review, marketplace_name,
+                    inventory_item_key, offer_id, data_json, created_at, updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                self._row_values(draft),
+            )
+            connection.commit()
+
+    def save_draft(self, draft: Draft) -> None:
+        draft.workflow.last_updated_at = utc_now()
+        with get_connection(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO drafts(
+                    id, sku, status, needs_review, marketplace_name,
+                    inventory_item_key, offer_id, data_json, created_at, updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    sku = excluded.sku,
+                    status = excluded.status,
+                    needs_review = excluded.needs_review,
+                    marketplace_name = excluded.marketplace_name,
+                    inventory_item_key = excluded.inventory_item_key,
+                    offer_id = excluded.offer_id,
+                    data_json = excluded.data_json,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at
+                """,
+                self._row_values(draft),
+            )
+            connection.commit()
+
+    def get_draft(self, draft_id: str) -> Draft | None:
+        with get_connection(self.database_path) as connection:
+            row = connection.execute(
+                "SELECT data_json FROM drafts WHERE id = ?",
+                (draft_id,),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return Draft.model_validate(json.loads(row["data_json"]))
+
+    def list_drafts(self, status: WorkflowStatus | None = None) -> list[Draft]:
+        query = "SELECT data_json FROM drafts"
+        params: tuple[object, ...] = ()
+        if status is not None:
+            query += " WHERE status = ?"
+            params = (status.value,)
+        query += " ORDER BY created_at ASC"
+
+        with get_connection(self.database_path) as connection:
+            rows = connection.execute(query, params).fetchall()
+
+        return [Draft.model_validate(json.loads(row["data_json"])) for row in rows]
+
+    def update_marketplace_refs(
+        self,
+        draft_id: str,
+        *,
+        inventory_item_key: str | None = None,
+        offer_id: str | None = None,
+    ) -> Draft:
+        draft = self.get_draft(draft_id)
+        if draft is None:
+            msg = f"Draft not found: {draft_id}"
+            raise KeyError(msg)
+
+        draft.marketplace.ebay.inventory_item_key = inventory_item_key
+        draft.marketplace.ebay.offer_id = offer_id
+        self.save_draft(draft)
+        return draft
+
+    @staticmethod
+    def _row_values(draft: Draft) -> tuple[object, ...]:
+        payload = draft.model_dump(mode="json", by_alias=True)
+        return (
+            draft.id,
+            draft.sku,
+            draft.workflow.status.value,
+            int(draft.workflow.needs_review),
+            "ebay",
+            draft.marketplace.ebay.inventory_item_key,
+            draft.marketplace.ebay.offer_id,
+            json.dumps(payload, ensure_ascii=False),
+            draft.workflow.created_at.isoformat(),
+            draft.workflow.last_updated_at.isoformat(),
+        )

--- a/app/drafts/workflow.py
+++ b/app/drafts/workflow.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from app.drafts.models import Draft, WorkflowStatus, utc_now
+
+ALLOWED_TRANSITIONS: dict[WorkflowStatus, set[WorkflowStatus]] = {
+    WorkflowStatus.DRAFT: {WorkflowStatus.CLASSIFIED, WorkflowStatus.BLOCKED, WorkflowStatus.ERROR},
+    WorkflowStatus.CLASSIFIED: {
+        WorkflowStatus.NEEDS_ATTENTION,
+        WorkflowStatus.READY_FOR_REVIEW,
+        WorkflowStatus.BLOCKED,
+        WorkflowStatus.ERROR,
+    },
+    WorkflowStatus.NEEDS_ATTENTION: {
+        WorkflowStatus.READY_FOR_REVIEW,
+        WorkflowStatus.BLOCKED,
+        WorkflowStatus.ERROR,
+    },
+    WorkflowStatus.READY_FOR_REVIEW: {
+        WorkflowStatus.READY_FOR_MARKETPLACE,
+        WorkflowStatus.BLOCKED,
+        WorkflowStatus.ERROR,
+    },
+    WorkflowStatus.READY_FOR_MARKETPLACE: {
+        WorkflowStatus.OFFER_CREATED,
+        WorkflowStatus.BLOCKED,
+        WorkflowStatus.ERROR,
+    },
+    WorkflowStatus.OFFER_CREATED: {WorkflowStatus.PUBLISHED, WorkflowStatus.ERROR},
+    WorkflowStatus.PUBLISHED: set(),
+    WorkflowStatus.BLOCKED: {WorkflowStatus.READY_FOR_REVIEW, WorkflowStatus.ERROR},
+    WorkflowStatus.ERROR: {
+        WorkflowStatus.DRAFT,
+        WorkflowStatus.CLASSIFIED,
+        WorkflowStatus.NEEDS_ATTENTION,
+        WorkflowStatus.READY_FOR_REVIEW,
+        WorkflowStatus.READY_FOR_MARKETPLACE,
+        WorkflowStatus.BLOCKED,
+    },
+}
+
+
+def transition_draft(draft: Draft, new_status: WorkflowStatus) -> Draft:
+    current_status = draft.workflow.status
+    if current_status == new_status:
+        return draft
+
+    if new_status not in ALLOWED_TRANSITIONS[current_status]:
+        msg = f"Invalid workflow transition: {current_status} -> {new_status}"
+        raise ValueError(msg)
+
+    draft.workflow.status = new_status
+    draft.workflow.last_updated_at = utc_now()
+    return draft

--- a/tests/test_draft_identity.py
+++ b/tests/test_draft_identity.py
@@ -1,0 +1,22 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from app.drafts.identity import derive_sku, generate_draft_id
+
+
+def test_generate_draft_id_uses_expected_format():
+    draft_id = generate_draft_id(datetime(2026, 4, 11, 12, 30, tzinfo=UTC))
+
+    assert draft_id.startswith("draft_20260411_")
+    assert len(draft_id.split("_", 2)[2]) == 8
+
+
+def test_derive_sku_is_deterministic():
+    assert derive_sku("draft_20260411_ab12cd34") == "oi-draft-20260411-ab12cd34"
+
+
+@pytest.mark.parametrize("draft_id", ["bad", "draft_20260411", "foo_20260411_ab12cd34"])
+def test_derive_sku_rejects_invalid_draft_id(draft_id: str):
+    with pytest.raises(ValueError):
+        derive_sku(draft_id)

--- a/tests/test_draft_repository.py
+++ b/tests/test_draft_repository.py
@@ -1,0 +1,62 @@
+from app.db.init_db import initialize_database
+from app.drafts.identity import derive_sku
+from app.drafts.models import Draft, WorkflowStatus
+from app.drafts.repository import DraftRepository
+from app.drafts.workflow import transition_draft
+
+
+def make_draft() -> Draft:
+    return Draft(
+        id="draft_20260411_ab12cd34",
+        sku=derive_sku("draft_20260411_ab12cd34"),
+        source={
+            "images": [
+                {
+                    "id": "img_01",
+                    "originalFilename": "IMG_1234.jpg",
+                    "storagePath": "/storage/drafts/draft_20260411_ab12cd34/images/01-original.jpg",
+                    "mimeType": "image/jpeg",
+                    "order": 1,
+                    "kind": "original",
+                }
+            ]
+        },
+    )
+
+
+def test_repository_persists_and_loads_draft(tmp_path):
+    db_path = tmp_path / "open_inserto.db"
+    initialize_database(db_path)
+    repository = DraftRepository(db_path)
+    draft = make_draft()
+
+    repository.create_draft(draft)
+    loaded = repository.get_draft(draft.id)
+
+    assert loaded is not None
+    assert loaded.id == draft.id
+    assert loaded.sku == draft.sku
+    assert loaded.source.images[0].storage_path.endswith("01-original.jpg")
+
+
+def test_repository_filters_by_status_and_updates_marketplace_refs(tmp_path):
+    db_path = tmp_path / "open_inserto.db"
+    initialize_database(db_path)
+    repository = DraftRepository(db_path)
+    draft = make_draft()
+
+    transition_draft(draft, WorkflowStatus.CLASSIFIED)
+    transition_draft(draft, WorkflowStatus.READY_FOR_REVIEW)
+    repository.save_draft(draft)
+    updated = repository.update_marketplace_refs(
+        draft.id,
+        inventory_item_key="inv-123",
+        offer_id="offer-456",
+    )
+
+    ready_for_review = repository.list_drafts(WorkflowStatus.READY_FOR_REVIEW)
+
+    assert len(ready_for_review) == 1
+    assert ready_for_review[0].id == draft.id
+    assert updated.marketplace.ebay.inventory_item_key == "inv-123"
+    assert updated.marketplace.ebay.offer_id == "offer-456"

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -1,0 +1,26 @@
+from app.drafts.identity import derive_sku
+from app.drafts.models import Draft, WorkflowStatus
+from app.drafts.workflow import transition_draft
+
+
+def make_draft() -> Draft:
+    return Draft(id="draft_20260411_ab12cd34", sku=derive_sku("draft_20260411_ab12cd34"))
+
+
+def test_valid_workflow_transition_updates_status():
+    draft = make_draft()
+
+    transition_draft(draft, WorkflowStatus.CLASSIFIED)
+
+    assert draft.workflow.status is WorkflowStatus.CLASSIFIED
+
+
+def test_invalid_workflow_transition_raises_error():
+    draft = make_draft()
+
+    try:
+        transition_draft(draft, WorkflowStatus.PUBLISHED)
+    except ValueError as exc:
+        assert "Invalid workflow transition" in str(exc)
+    else:
+        raise AssertionError("Expected invalid workflow transition to fail")


### PR DESCRIPTION
## Summary

Führt das MVP-Draft-Datenmodell als Pydantic-Struktur ein, ergänzt eine SQLite-Repository-Schicht für persistente Drafts und modelliert Workflow-Statusübergänge explizit im Code.

## Changes

- ergänzt `app/drafts` mit Modellen für `source`, `listing`, `marketplace`, `workflow`
- kapselt Draft-ID- und SKU-Erzeugung in `identity.py`
- erzwingt erlaubte Statusübergänge in `workflow.py`
- erweitert das SQLite-Schema um `drafts` samt Indizes und Schema-Version 2
- ergänzt Tests für ID/SKU, Repository-Persistenz und Workflow-Übergänge

## Testing

- `source .venv/bin/activate && pytest` → 11 Tests erfolgreich

Fixes e-Luksch/open-inserto#4