### PR TITLE
feat: add MVP upload flow and local image storage

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     app_port: int = 8000
     app_debug: bool = True
 
+    project_dir: Path = Path(".")
     data_dir: Path = Path("data")
     database_url: str = "sqlite:///data/open_inserto.db"
 
@@ -41,6 +42,15 @@ class Settings(BaseSettings):
 @lru_cache
 def get_settings() -> Settings:
     settings = Settings()
+    settings.project_dir = settings.project_dir.resolve()
+    if not settings.data_dir.is_absolute():
+        settings.data_dir = (settings.project_dir / settings.data_dir).resolve()
+
+    database_path = settings.database_path
+    if not database_path.is_absolute():
+        database_path = (settings.project_dir / database_path).resolve()
+        settings.database_url = f"sqlite:///{database_path}"
+
     settings.data_dir.mkdir(parents=True, exist_ok=True)
-    settings.database_path.parent.mkdir(parents=True, exist_ok=True)
+    database_path.parent.mkdir(parents=True, exist_ok=True)
     return settings

--- a/app/drafts/upload_service.py
+++ b/app/drafts/upload_service.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import BinaryIO
+from uuid import uuid4
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+from pillow_heif import register_heif_opener
+
+from app.drafts.identity import derive_sku, generate_draft_id
+from app.drafts.models import Draft, SourceImage
+
+register_heif_opener()
+
+ALLOWED_MIME_TYPES = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "image/gif": ".gif",
+    "image/bmp": ".bmp",
+    "image/tiff": ".tif",
+}
+ALLOWED_EXTENSIONS = set(ALLOWED_MIME_TYPES.values())
+MAX_UPLOAD_IMAGES = 20
+MIN_LONGEST_SIDE = 500
+NORMALIZED_MIME_TYPE = "image/jpeg"
+NORMALIZED_SUFFIX = ".jpg"
+
+
+class UploadValidationError(ValueError):
+    pass
+
+
+@dataclass(slots=True)
+class UploadAsset:
+    filename: str
+    content_type: str | None
+    stream: BinaryIO
+
+
+@dataclass(slots=True)
+class UploadResult:
+    draft: Draft
+    original_paths: list[str]
+
+
+class DraftUploadService:
+    def __init__(self, data_dir: Path):
+        self.data_dir = data_dir
+        self.drafts_dir = data_dir / "drafts"
+        self.drafts_dir.mkdir(parents=True, exist_ok=True)
+
+    def create_draft_from_upload(
+        self,
+        *,
+        files: list[UploadAsset],
+        notes: str = "",
+        user_input: dict[str, str] | None = None,
+    ) -> UploadResult:
+        normalized_user_input = {key: value.strip() for key, value in (user_input or {}).items() if value.strip()}
+        validated_files = self._validate_files(files)
+
+        draft_id = generate_draft_id()
+        draft_dir = self.drafts_dir / draft_id
+        originals_dir = draft_dir / "images" / "originals"
+        normalized_dir = draft_dir / "images" / "normalized"
+        originals_dir.mkdir(parents=True, exist_ok=True)
+        normalized_dir.mkdir(parents=True, exist_ok=True)
+
+        source_images: list[SourceImage] = []
+        original_paths: list[str] = []
+
+        for index, asset in enumerate(validated_files, start=1):
+            image, original_bytes = self._load_image(asset)
+            normalized_image = ImageOps.exif_transpose(image)
+            if max(normalized_image.size) < MIN_LONGEST_SIDE:
+                msg = (
+                    f"{asset.filename or f'Bild {index}'} ist zu klein. "
+                    f"Die längste Seite muss mindestens {MIN_LONGEST_SIDE}px haben."
+                )
+                raise UploadValidationError(msg)
+
+            original_suffix = self._detect_suffix(asset)
+            original_path = originals_dir / f"{index:02d}-original{original_suffix}"
+            original_path.write_bytes(original_bytes)
+            original_paths.append(str(original_path.relative_to(self.data_dir.parent)))
+
+            normalized_path = normalized_dir / f"{index:02d}-normalized{NORMALIZED_SUFFIX}"
+            rgb_image = normalized_image.convert("RGB")
+            rgb_image.save(normalized_path, format="JPEG", quality=92, optimize=True)
+
+            source_images.append(
+                SourceImage(
+                    id=f"img_{uuid4().hex[:8]}",
+                    originalFilename=asset.filename or f"upload-{index}{original_suffix}",
+                    storagePath=str(normalized_path.relative_to(self.data_dir.parent)),
+                    mimeType=NORMALIZED_MIME_TYPE,
+                    order=index,
+                    kind="normalized",
+                )
+            )
+
+        draft = Draft(
+            id=draft_id,
+            sku=derive_sku(draft_id),
+            source={
+                "images": source_images,
+                "notes": notes.strip(),
+                "userInput": normalized_user_input,
+            },
+        )
+        return UploadResult(draft=draft, original_paths=original_paths)
+
+    def _validate_files(self, files: list[UploadAsset]) -> list[UploadAsset]:
+        non_empty = [file for file in files if (file.filename or "").strip()]
+        if not non_empty:
+            raise UploadValidationError("Bitte mindestens ein Bild auswählen.")
+        if len(non_empty) > MAX_UPLOAD_IMAGES:
+            raise UploadValidationError(f"Bitte maximal {MAX_UPLOAD_IMAGES} Bilder hochladen.")
+        return non_empty
+
+    def _load_image(self, asset: UploadAsset) -> tuple[Image.Image, bytes]:
+        content = asset.stream.read()
+        if not content:
+            raise UploadValidationError(f"{asset.filename or 'Eine Datei'} ist leer.")
+
+        suffix = self._detect_suffix(asset)
+        if suffix not in ALLOWED_EXTENSIONS:
+            raise UploadValidationError(
+                f"{asset.filename or 'Die Datei'} hat einen nicht unterstützten Bildtyp."
+            )
+
+        try:
+            image = Image.open(BytesIO(content))
+            image.load()
+        except UnidentifiedImageError as exc:
+            raise UploadValidationError(
+                f"{asset.filename or 'Die Datei'} konnte nicht als Bild gelesen werden."
+            ) from exc
+
+        detected_mime = Image.MIME.get(image.format or "")
+        allowed_by_header = (asset.content_type or "").lower() in ALLOWED_MIME_TYPES
+        allowed_by_decoder = (detected_mime or "").lower() in ALLOWED_MIME_TYPES
+        if not (allowed_by_header or allowed_by_decoder):
+            raise UploadValidationError(
+                f"{asset.filename or 'Die Datei'} ist kein unterstütztes Bildformat."
+            )
+
+        return image, content
+
+    def _detect_suffix(self, asset: UploadAsset) -> str:
+        filename = (asset.filename or "").lower()
+        suffix = Path(filename).suffix
+        if suffix in ALLOWED_EXTENSIONS:
+            return ".jpg" if suffix == ".jpeg" else suffix
+
+        content_type = (asset.content_type or "").lower()
+        detected = ALLOWED_MIME_TYPES.get(content_type)
+        if detected:
+            return detected
+
+        return suffix

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ def create_app() -> FastAPI:
     )
     app.include_router(web_router)
     app.mount("/static", StaticFiles(directory="app/static"), name="static")
+    app.mount("/data", StaticFiles(directory=settings.data_dir), name="data")
     return app
 
 

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2,40 +2,219 @@
   color-scheme: light;
   font-family: Inter, system-ui, sans-serif;
   line-height: 1.5;
+  --bg: #f4f7fb;
+  --surface: #ffffff;
+  --surface-muted: #eef3fb;
+  --text: #172033;
+  --text-soft: #5e6a82;
+  --border: rgba(117, 132, 168, 0.18);
+  --shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+  --primary: #2563eb;
+  --primary-soft: rgba(37, 99, 235, 0.12);
+  --danger: #b42318;
+  --danger-soft: #fef3f2;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: #f7f8fb;
-  color: #1c2434;
+  background: radial-gradient(circle at top, #ffffff, var(--bg) 55%);
+  color: var(--text);
 }
 
 .container {
-  max-width: 900px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 3rem 1.25rem;
+  padding: 3rem 1.25rem 4rem;
 }
 
 .hero {
   margin-bottom: 2rem;
 }
 
+.hero--compact {
+  margin-bottom: 1.5rem;
+}
+
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #6a7282;
+  color: var(--text-soft);
   font-size: 0.8rem;
+  font-weight: 700;
 }
 
-.card-grid {
+.card-grid,
+.detail-grid {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.card {
-  background: white;
+.card,
+.panel {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.4rem;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.upload-layout {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  align-items: start;
+}
+
+.upload-dropzone {
+  min-height: 100%;
+  border: 1.5px dashed rgba(37, 99, 235, 0.25);
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.05), rgba(37, 99, 235, 0.02));
+}
+
+.upload-dropzone.is-dragover {
+  border-color: var(--primary);
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.12), rgba(37, 99, 235, 0.05));
+}
+
+.upload-picker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 1rem 0;
+  padding: 0.9rem 1.2rem;
+  border-radius: 999px;
+  background: var(--text);
+  color: white;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.upload-picker input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.upload-help {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.upload-help span,
+.preview-meta,
+code {
+  color: var(--text-soft);
+  font-size: 0.92rem;
+}
+
+.upload-help span {
+  background: rgba(23, 32, 51, 0.06);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+}
+
+.preview-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.preview-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.8rem;
+  border-radius: 18px;
+  background: var(--surface-muted);
+  border: 1px solid rgba(117, 132, 168, 0.14);
+}
+
+.preview-card img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 14px;
+  background: #dbe4f5;
+}
+
+.field-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.field--full {
+  margin-bottom: 1rem;
+}
+
+.field input,
+.field textarea {
+  width: 100%;
+  border: 1px solid rgba(117, 132, 168, 0.28);
   border-radius: 16px;
-  padding: 1.25rem;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  padding: 0.9rem 1rem;
+  font: inherit;
+  background: white;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 7.5rem;
+}
+
+.button {
+  border: 0;
+  border-radius: 16px;
+  padding: 0.95rem 1.15rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.button--primary {
+  background: var(--primary);
+  color: white;
+  margin-top: 1.2rem;
+}
+
+.alert {
+  border-radius: 18px;
+  padding: 1rem 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.alert--error {
+  background: var(--danger-soft);
+  border: 1px solid rgba(180, 35, 24, 0.18);
+  color: var(--danger);
+}
+
+.empty-state {
+  color: var(--text-soft);
+  margin: 0;
+}
+
+.image-list-panel {
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 900px) {
+  .upload-layout {
+    grid-template-columns: 1fr;
+  }
 }

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -39,6 +39,12 @@ body {
   margin-bottom: 1.5rem;
 }
 
+.hero-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -178,12 +184,16 @@ code {
 }
 
 .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 0;
   border-radius: 16px;
   padding: 0.95rem 1.15rem;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
+  text-decoration: none;
 }
 
 .button--primary {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} – Draft {{ draft.id }}{% endblock %}
+
+{% block content %}
+<section class="hero hero--compact">
+  <p class="eyebrow">Draft erstellt</p>
+  <h1>{{ draft.id }}</h1>
+  <p>SKU: <strong>{{ draft.sku }}</strong></p>
+</section>
+
+<section class="card-grid detail-grid">
+  <article class="card">
+    <h2>Status</h2>
+    <ul>
+      <li><strong>Workflow:</strong> {{ draft.workflow.status }}</li>
+      <li><strong>Review nötig:</strong> {{ 'Ja' if draft.workflow.needs_review else 'Nein' }}</li>
+      <li><strong>Bilder:</strong> {{ draft.source.images | length }}</li>
+    </ul>
+  </article>
+
+  <article class="card">
+    <h2>Zusatzinfos</h2>
+    {% if draft.source.notes %}
+      <p><strong>Notizen:</strong><br>{{ draft.source.notes }}</p>
+    {% else %}
+      <p>Keine Notizen hinterlegt.</p>
+    {% endif %}
+
+    {% if draft.source.user_input %}
+      <ul>
+        {% for key, value in draft.source.user_input.items() %}
+          <li><strong>{{ key }}:</strong> {{ value }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </article>
+</section>
+
+<section class="panel image-list-panel">
+  <div>
+    <p class="eyebrow">Gespeicherte Bilder</p>
+    <h2>Normalisierte Arbeitskopien</h2>
+  </div>
+
+  <div class="preview-grid">
+    {% for image in draft.source.images %}
+      <article class="preview-card">
+        <img src="/{{ image.storage_path }}" alt="{{ image.original_filename }}">
+        <strong>{{ image.order }}. {{ image.original_filename }}</strong>
+        <span class="preview-meta">{{ image.mime_type }} · {{ image.kind }}</span>
+        <code>{{ image.storage_path }}</code>
+      </article>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,12 +4,16 @@
 
 {% block content %}
 <section class="hero">
-  <p class="eyebrow">MVP scaffold</p>
+  <p class="eyebrow">MVP Upload Flow</p>
   <h1>{{ app_name }}</h1>
   <p>
-    FastAPI läuft, server-rendered Templates sind eingebunden und die SQLite-Basis
-    wurde vorbereitet.
+    Der aktuelle Stand deckt den Draft-Upload bereits end-to-end ab: Bilder hochladen,
+    lokal speichern, normalisieren und als neuen Draft vorbereiten.
   </p>
+
+  <div class="hero-actions">
+    <a class="button button--primary" href="/drafts/upload">Zum Upload</a>
+  </div>
 </section>
 
 <section class="card-grid">
@@ -22,11 +26,11 @@
   </article>
 
   <article class="card">
-    <h2>Nächste Ausbaustufen</h2>
+    <h2>Bereits umgesetzt</h2>
     <ul>
-      <li>Bild-Upload</li>
-      <li>Draft-Datenmodell</li>
-      <li>eBay-Draft-Workflow</li>
+      <li>Mehrfach-Bildupload mit Vorschau</li>
+      <li>Lokale Bildspeicherung und Format-Normalisierung</li>
+      <li>Erzeugung eines neuen Drafts aus den Upload-Daten</li>
     </ul>
   </article>
 </section>

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -1,0 +1,137 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} – Upload{% endblock %}
+
+{% block content %}
+<section class="upload-shell">
+  <div class="hero hero--compact">
+    <p class="eyebrow">MVP Upload Flow</p>
+    <h1>Bilder hochladen</h1>
+    <p>
+      Lade mehrere Bilder hoch, ergänze optionale Infos und starte damit einen neuen Draft.
+      Die Bilder werden lokal gespeichert und für den weiteren Workflow normalisiert.
+    </p>
+  </div>
+
+  {% if errors %}
+    <div class="alert alert--error">
+      <strong>Upload fehlgeschlagen.</strong>
+      <ul>
+        {% for error in errors %}
+          <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <form class="upload-layout" method="post" action="/drafts/upload" enctype="multipart/form-data">
+    <section class="panel upload-dropzone" data-dropzone>
+      <div>
+        <p class="eyebrow">Bilder</p>
+        <h2>Mehrfach-Upload mit Vorschau</h2>
+        <p>Unterstützt: JPG, PNG, WEBP, HEIC/HEIF, GIF, BMP und TIFF.</p>
+      </div>
+
+      <label class="upload-picker">
+        <input type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
+        <span>Dateien auswählen</span>
+      </label>
+
+      <div class="upload-help">
+        <span>Mindestens 1 Bild</span>
+        <span>Maximal 20 Bilder</span>
+        <span>Mindestens 500 px auf der längsten Seite</span>
+      </div>
+
+      <div class="preview-grid" data-preview-grid>
+        <p class="empty-state">Noch keine Bilder ausgewählt.</p>
+      </div>
+    </section>
+
+    <section class="panel form-panel">
+      <div>
+        <p class="eyebrow">Zusatzinfos</p>
+        <h2>Kontext für den Draft</h2>
+      </div>
+
+      <label class="field field--full">
+        <span>Notizen</span>
+        <textarea name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Fundort, Preisidee ...">{{ form_values.notes or '' }}</textarea>
+      </label>
+
+      <div class="field-grid">
+        {% for field_name, field_label in extra_fields %}
+          <label class="field">
+            <span>{{ field_label }}</span>
+            <input type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
+          </label>
+        {% endfor %}
+      </div>
+
+      <button class="button button--primary" type="submit">Draft erstellen</button>
+    </section>
+  </form>
+</section>
+
+<script>
+  const input = document.querySelector('[data-image-input]');
+  const previewGrid = document.querySelector('[data-preview-grid]');
+  const dropzone = document.querySelector('[data-dropzone]');
+
+  const renderPreviews = () => {
+    const files = Array.from(input.files || []);
+    if (!files.length) {
+      previewGrid.innerHTML = '<p class="empty-state">Noch keine Bilder ausgewählt.</p>';
+      return;
+    }
+
+    previewGrid.innerHTML = '';
+    files.forEach((file, index) => {
+      const item = document.createElement('article');
+      item.className = 'preview-card';
+
+      const title = document.createElement('strong');
+      title.textContent = `${index + 1}. ${file.name}`;
+      item.appendChild(title);
+
+      const meta = document.createElement('span');
+      meta.className = 'preview-meta';
+      meta.textContent = `${Math.round(file.size / 1024)} KB · ${file.type || 'unbekannt'}`;
+      item.appendChild(meta);
+
+      if (file.type.startsWith('image/')) {
+        const img = document.createElement('img');
+        img.alt = file.name;
+        img.loading = 'lazy';
+        img.src = URL.createObjectURL(file);
+        item.appendChild(img);
+      }
+
+      previewGrid.appendChild(item);
+    });
+  };
+
+  input?.addEventListener('change', renderPreviews);
+
+  ['dragenter', 'dragover'].forEach((eventName) => {
+    dropzone?.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      dropzone.classList.add('is-dragover');
+    });
+  });
+
+  ['dragleave', 'drop'].forEach((eventName) => {
+    dropzone?.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      dropzone.classList.remove('is-dragover');
+    });
+  });
+
+  dropzone?.addEventListener('drop', (event) => {
+    const files = event.dataTransfer?.files;
+    if (!files?.length) return;
+    input.files = files;
+    renderPreviews();
+  });
+</script>
+{% endblock %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -1,11 +1,34 @@
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile, status
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from app.core.config import get_settings
+from app.drafts.repository import DraftRepository
+from app.drafts.upload_service import DraftUploadService, UploadAsset, UploadValidationError
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
+
+
+EXTRA_FIELDS = [
+    ("product_name", "Produktname"),
+    ("condition", "Zustand"),
+    ("accessories", "Zubehör"),
+    ("hints", "Hinweise"),
+]
+
+
+def build_context(request: Request, **extra):
+    settings = get_settings()
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "ebay_mode": settings.ebay_mode,
+        "database_url": settings.database_url,
+        "extra_fields": EXTRA_FIELDS,
+    }
+    context.update(extra)
+    return context
 
 
 @router.get("/health")
@@ -20,13 +43,81 @@ def health() -> dict[str, str]:
 
 @router.get("/", response_class=HTMLResponse)
 def index(request: Request):
-    settings = get_settings()
+    return templates.TemplateResponse(request, "index.html", build_context(request))
+
+
+@router.get("/drafts/upload", response_class=HTMLResponse)
+def upload_page(request: Request):
     return templates.TemplateResponse(
         request,
-        "index.html",
-        {
-            "app_name": settings.app_name,
-            "ebay_mode": settings.ebay_mode,
-            "database_url": settings.database_url,
-        },
+        "upload.html",
+        build_context(request, errors=[], form_values={}),
+    )
+
+
+@router.post("/drafts/upload", response_class=HTMLResponse)
+async def upload_draft(
+    request: Request,
+    images: list[UploadFile] = File(default_factory=list),
+    notes: str = Form(default=""),
+    product_name: str = Form(default=""),
+    condition: str = Form(default=""),
+    accessories: str = Form(default=""),
+    hints: str = Form(default=""),
+):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    service = DraftUploadService(settings.data_dir)
+    form_values = {
+        "notes": notes,
+        "product_name": product_name,
+        "condition": condition,
+        "accessories": accessories,
+        "hints": hints,
+    }
+
+    assets = [
+        UploadAsset(filename=image.filename, content_type=image.content_type, stream=image.file)
+        for image in images
+        if image.filename
+    ]
+
+    try:
+        result = service.create_draft_from_upload(
+            files=assets,
+            notes=notes,
+            user_input={
+                "product_name": product_name,
+                "condition": condition,
+                "accessories": accessories,
+                "hints": hints,
+            },
+        )
+    except UploadValidationError as exc:
+        return templates.TemplateResponse(
+            request,
+            "upload.html",
+            build_context(request, errors=[str(exc)], form_values=form_values),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    finally:
+        for image in images:
+            await image.close()
+
+    repository.save_draft(result.draft)
+    return RedirectResponse(url=f"/drafts/{result.draft.id}", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.get("/drafts/{draft_id}", response_class=HTMLResponse)
+def draft_detail(request: Request, draft_id: str):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    draft = repository.get_draft(draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    return templates.TemplateResponse(
+        request,
+        "draft_detail.html",
+        build_context(request, draft=draft),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ jinja2==3.1.6
 pydantic-settings==2.13.1
 pytest==9.0.3
 httpx==0.28.1
+python-multipart==0.0.20
+pillow==11.2.1
+pillow-heif==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ jinja2==3.1.6
 pydantic-settings==2.13.1
 pytest==9.0.3
 httpx==0.28.1
-python-multipart==0.0.20
-pillow==11.2.1
-pillow-heif==0.22.0
+python-multipart==0.0.26
+pillow==12.2.0
+pillow-heif==1.3.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,4 +17,6 @@ def test_index_page_renders():
 
     assert response.status_code == 200
     assert "Open Inserto" in response.text
-    assert "MVP scaffold" in response.text
+    assert "MVP Upload Flow" in response.text
+    assert "Zum Upload" in response.text
+    assert 'href="/drafts/upload"' in response.text

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app.core.config import get_settings
+from app.main import create_app
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'data' / 'test.db'}")
+    get_settings.cache_clear()
+    app = create_app()
+    with TestClient(app) as test_client:
+        yield test_client
+    get_settings.cache_clear()
+
+
+def build_image_bytes(*, image_format: str = "JPEG", size: tuple[int, int] = (1200, 900), color=(64, 114, 255)) -> bytes:
+    image = Image.new("RGB", size, color=color)
+    buffer = BytesIO()
+    image.save(buffer, format=image_format)
+    return buffer.getvalue()
+
+
+def test_upload_page_renders(client: TestClient):
+    response = client.get("/drafts/upload")
+
+    assert response.status_code == 200
+    assert "Mehrfach-Upload mit Vorschau" in response.text
+    assert "Draft erstellen" in response.text
+
+
+def test_post_upload_creates_draft_and_files(client: TestClient):
+    files = [
+        ("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg")),
+        ("images", ("back.png", build_image_bytes(image_format="PNG"), "image/png")),
+    ]
+    data = {
+        "notes": "Leichte Gebrauchsspuren",
+        "product_name": "Testgerät",
+        "condition": "gebraucht",
+        "accessories": "Netzteil",
+        "hints": "Seriennummer verdeckt",
+    }
+
+    response = client.post("/drafts/upload", files=files, data=data, follow_redirects=False)
+
+    assert response.status_code == 303
+    location = response.headers["location"]
+    assert location.startswith("/drafts/draft_")
+
+    detail = client.get(location)
+    assert detail.status_code == 200
+    assert "Leichte Gebrauchsspuren" in detail.text
+    assert "Testgerät" in detail.text
+    assert "front.jpg" in detail.text
+    assert "back.png" in detail.text
+
+    settings = get_settings()
+    originals = sorted(settings.data_dir.glob("drafts/*/images/originals/*"))
+    normalized = sorted(settings.data_dir.glob("drafts/*/images/normalized/*"))
+    assert len(originals) == 2
+    assert len(normalized) == 2
+
+
+def test_post_upload_without_images_returns_validation_error(client: TestClient):
+    response = client.post("/drafts/upload", data={"notes": "Ohne Bild"})
+
+    assert response.status_code == 400
+    assert "Bitte mindestens ein Bild auswählen." in response.text
+
+
+def test_post_upload_rejects_invalid_file_type(client: TestClient):
+    response = client.post(
+        "/drafts/upload",
+        files=[("images", ("notes.txt", b"keine bilddatei", "text/plain"))],
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "nicht unterstützten Bildtyp" in response.text or "kein unterstütztes Bildformat" in response.text
+
+
+def test_post_upload_rejects_too_small_images(client: TestClient):
+    response = client.post(
+        "/drafts/upload",
+        files=[("images", ("small.jpg", build_image_bytes(size=(320, 240)), "image/jpeg"))],
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "mindestens 500px" in response.text


### PR DESCRIPTION
## Summary
- add a modern multi-image upload flow with preview, validation and a first draft detail page
- normalize uploaded images to JPEG for the draft workflow while keeping original assets on disk
- persist uploaded draft data plus optional notes/user input and cover the flow with upload tests

## Testing
- pytest

Closes #5