### PR TITLE
feat: add heuristic draft analysis service

### DIFF
--- a/app/drafts/__init__.py
+++ b/app/drafts/__init__.py
@@ -1,3 +1,4 @@
+from app.drafts.analysis import DraftAnalysisResult, HeuristicDraftAnalysisService, apply_analysis_result
 from app.drafts.identity import derive_sku, generate_draft_id
 from app.drafts.models import Draft, WorkflowStatus
 from app.drafts.repository import DraftRepository
@@ -5,8 +6,11 @@ from app.drafts.workflow import transition_draft
 
 __all__ = [
     "Draft",
+    "DraftAnalysisResult",
     "DraftRepository",
+    "HeuristicDraftAnalysisService",
     "WorkflowStatus",
+    "apply_analysis_result",
     "derive_sku",
     "generate_draft_id",
     "transition_draft",

--- a/app/drafts/analysis.py
+++ b/app/drafts/analysis.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+from typing import Protocol
+
+from app.drafts.models import Draft, ListingData, WorkflowStatus
+
+
+@dataclass(slots=True)
+class DraftAnalysisResult:
+    listing: ListingData
+    workflow_status: WorkflowStatus
+    needs_review: bool = True
+    missing_information: list[str] | None = None
+    confidence_notes: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.missing_information is None:
+            self.missing_information = []
+        if self.confidence_notes is None:
+            self.confidence_notes = []
+
+
+class DraftAnalysisService(Protocol):
+    def analyze(self, draft: Draft) -> DraftAnalysisResult: ...
+
+
+class HeuristicDraftAnalysisService:
+    def analyze(self, draft: Draft) -> DraftAnalysisResult:
+        user_input = draft.source.user_input
+        notes = draft.source.notes.strip()
+
+        product_name = _clean_text(user_input.get("product_name"))
+        condition = _clean_text(user_input.get("condition"))
+        accessories = _split_lines_or_csv(user_input.get("accessories"))
+        issues = _collect_issues(user_input.get("hints"), notes)
+
+        missing_information: list[str] = []
+        confidence_notes: list[str] = [
+            "MVP-Heuristik: Vorschläge basieren nur auf Zusatzinfos und vorhandenen Bildern, nicht auf echter Bildanalyse.",
+        ]
+
+        if not product_name:
+            missing_information.append("Produktname unklar")
+        if not condition:
+            missing_information.append("Zustand fehlt")
+        if not notes and not issues:
+            missing_information.append("Beschreibung unvollständig")
+
+        if not accessories:
+            confidence_notes.append("Zubehör wurde nicht sicher erkannt und bleibt leer, bis es bestätigt wird.")
+        if draft.source.images:
+            confidence_notes.append(
+                f"{len(draft.source.images)} Bild(er) liegen vor, wurden aber im MVP noch nicht inhaltlich ausgewertet."
+            )
+
+        listing = ListingData(
+            title=product_name,
+            condition=condition,
+            includedItems=accessories,
+            issues=issues,
+            descriptionHtml=_build_description_html(
+                product_name=product_name,
+                condition=condition,
+                accessories=accessories,
+                notes=notes,
+                issues=issues,
+                missing_information=missing_information,
+                confidence_notes=confidence_notes,
+            ),
+        )
+
+        workflow_status = (
+            WorkflowStatus.NEEDS_ATTENTION if missing_information else WorkflowStatus.CLASSIFIED
+        )
+
+        return DraftAnalysisResult(
+            listing=listing,
+            workflow_status=workflow_status,
+            needs_review=True,
+            missing_information=missing_information,
+            confidence_notes=confidence_notes,
+        )
+
+
+def apply_analysis_result(draft: Draft, analysis: DraftAnalysisResult) -> Draft:
+    draft.listing = analysis.listing
+    draft.workflow.status = analysis.workflow_status
+    draft.workflow.needs_review = analysis.needs_review
+    draft.workflow.missing_information = list(analysis.missing_information or [])
+    draft.workflow.last_updated_at = draft.workflow.last_updated_at
+
+    confidence_notes = list(analysis.confidence_notes or [])
+    if confidence_notes:
+        draft.listing.attributes["confidenceNotes"] = confidence_notes
+    else:
+        draft.listing.attributes.pop("confidenceNotes", None)
+
+    return draft
+
+
+def _clean_text(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _split_lines_or_csv(value: object) -> list[str]:
+    text = _clean_text(value)
+    if not text:
+        return []
+
+    normalized = text.replace("\r", "\n")
+    parts = [part.strip(" -•\t") for chunk in normalized.split("\n") for part in chunk.split(",")]
+    return [part for part in parts if part]
+
+
+def _collect_issues(*values: object) -> list[str]:
+    issues: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for item in _split_lines_or_csv(value):
+            key = item.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            issues.append(item)
+    return issues
+
+
+def _build_description_html(
+    *,
+    product_name: str,
+    condition: str,
+    accessories: list[str],
+    notes: str,
+    issues: list[str],
+    missing_information: list[str],
+    confidence_notes: list[str],
+) -> str:
+    sections: list[str] = []
+
+    title = product_name or "Unbenannter Artikel"
+    sections.append(f"<p><strong>{escape(title)}</strong></p>")
+
+    details: list[str] = []
+    if condition:
+        details.append(f"<li><strong>Zustand:</strong> {escape(condition)}</li>")
+    if accessories:
+        details.append(
+            "<li><strong>Zubehör:</strong> " + ", ".join(escape(item) for item in accessories) + "</li>"
+        )
+    if details:
+        sections.append("<ul>" + "".join(details) + "</ul>")
+
+    if notes:
+        sections.append(f"<p><strong>Notizen:</strong> {escape(notes)}</p>")
+
+    if issues:
+        sections.append(
+            "<p><strong>Hinweise / offene Punkte:</strong></p><ul>"
+            + "".join(f"<li>{escape(item)}</li>" for item in issues)
+            + "</ul>"
+        )
+
+    if missing_information:
+        sections.append(
+            "<p><strong>Fehlende Informationen:</strong></p><ul>"
+            + "".join(f"<li>{escape(item)}</li>" for item in missing_information)
+            + "</ul>"
+        )
+
+    if confidence_notes:
+        sections.append(
+            "<p><strong>Unsicherheiten:</strong></p><ul>"
+            + "".join(f"<li>{escape(item)}</li>" for item in confidence_notes)
+            + "</ul>"
+        )
+
+    return "".join(sections)

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -11,7 +11,7 @@
 
 <section class="card-grid detail-grid">
   <article class="card">
-    <h2>Status</h2>
+    <h2>Übersicht</h2>
     <ul>
       <li><strong>Workflow:</strong> {{ draft.workflow.status }}</li>
       <li><strong>Review nötig:</strong> {{ 'Ja' if draft.workflow.needs_review else 'Nein' }}</li>
@@ -19,41 +19,44 @@
     </ul>
 
     {% if draft.workflow.missing_information %}
-      <h3>Fehlende Informationen</h3>
+      <h3>Vor Review noch offen</h3>
       <ul>
         {% for item in draft.workflow.missing_information %}
           <li>{{ item }}</li>
         {% endfor %}
       </ul>
-    {% endif %}
-  </article>
-
-  <article class="card">
-    <h2>Zusatzinfos</h2>
-    {% if draft.source.notes %}
-      <p><strong>Notizen:</strong><br>{{ draft.source.notes }}</p>
     {% else %}
-      <p>Keine Notizen hinterlegt.</p>
-    {% endif %}
-
-    {% if draft.source.user_input %}
-      <ul>
-        {% for key, value in draft.source.user_input.items() %}
-          <li><strong>{{ key }}:</strong> {{ value }}</li>
-        {% endfor %}
-      </ul>
+      <p>Aktuell fehlen keine Pflichtangaben aus den vorhandenen Eingaben.</p>
     {% endif %}
   </article>
 
   <article class="card">
-    <h2>Analyse-Vorschlag</h2>
+    <h2>Deine Angaben</h2>
+    <ul>
+      <li><strong>Produktname:</strong> {{ draft.source.user_input.get('product_name') or '–' }}</li>
+      <li><strong>Zustand:</strong> {{ draft.source.user_input.get('condition') or '–' }}</li>
+      <li><strong>Zubehör:</strong> {{ draft.source.user_input.get('accessories') or '–' }}</li>
+      <li><strong>Hinweise:</strong> {{ draft.source.user_input.get('hints') or '–' }}</li>
+    </ul>
+
+    {% if draft.source.notes %}
+      <p><strong>Freitext-Notizen:</strong><br>{{ draft.source.notes }}</p>
+    {% else %}
+      <p>Keine zusätzlichen Notizen hinterlegt.</p>
+    {% endif %}
+  </article>
+
+  <article class="card">
+    <h2>Systemvorschlag</h2>
+    <p>Das System leitet daraus einen ersten Entwurf ab. Das ist nur ein Vorschlag zur Prüfung.</p>
+
     <ul>
       <li><strong>Titel:</strong> {{ draft.listing.title or '–' }}</li>
       <li><strong>Zustand:</strong> {{ draft.listing.condition or '–' }}</li>
       <li><strong>Kategorie:</strong> {{ draft.listing.category_suggestion or '–' }}</li>
     </ul>
 
-    <p><strong>Zubehör:</strong></p>
+    <h3>Erkanntes Zubehör</h3>
     {% if draft.listing.included_items %}
       <ul>
         {% for item in draft.listing.included_items %}
@@ -64,7 +67,7 @@
       <p>Kein Zubehör vorgeschlagen.</p>
     {% endif %}
 
-    <p><strong>Hinweise:</strong></p>
+    <h3>Erkannte Hinweise</h3>
     {% if draft.listing.issues %}
       <ul>
         {% for item in draft.listing.issues %}
@@ -77,17 +80,12 @@
 
     {% set confidence_notes = draft.listing.attributes.get('confidenceNotes', []) %}
     {% if confidence_notes %}
-      <p><strong>Unsicherheiten:</strong></p>
+      <h3>Unsicherheiten des Vorschlags</h3>
       <ul>
         {% for item in confidence_notes %}
           <li>{{ item }}</li>
         {% endfor %}
       </ul>
-    {% endif %}
-
-    {% if draft.listing.description_html %}
-      <p><strong>Beschreibung:</strong></p>
-      <div>{{ draft.listing.description_html | safe }}</div>
     {% endif %}
   </article>
 </section>

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -17,6 +17,15 @@
       <li><strong>Review nötig:</strong> {{ 'Ja' if draft.workflow.needs_review else 'Nein' }}</li>
       <li><strong>Bilder:</strong> {{ draft.source.images | length }}</li>
     </ul>
+
+    {% if draft.workflow.missing_information %}
+      <h3>Fehlende Informationen</h3>
+      <ul>
+        {% for item in draft.workflow.missing_information %}
+          <li>{{ item }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </article>
 
   <article class="card">
@@ -33,6 +42,52 @@
           <li><strong>{{ key }}:</strong> {{ value }}</li>
         {% endfor %}
       </ul>
+    {% endif %}
+  </article>
+
+  <article class="card">
+    <h2>Analyse-Vorschlag</h2>
+    <ul>
+      <li><strong>Titel:</strong> {{ draft.listing.title or '–' }}</li>
+      <li><strong>Zustand:</strong> {{ draft.listing.condition or '–' }}</li>
+      <li><strong>Kategorie:</strong> {{ draft.listing.category_suggestion or '–' }}</li>
+    </ul>
+
+    <p><strong>Zubehör:</strong></p>
+    {% if draft.listing.included_items %}
+      <ul>
+        {% for item in draft.listing.included_items %}
+          <li>{{ item }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>Kein Zubehör vorgeschlagen.</p>
+    {% endif %}
+
+    <p><strong>Hinweise:</strong></p>
+    {% if draft.listing.issues %}
+      <ul>
+        {% for item in draft.listing.issues %}
+          <li>{{ item }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>Keine Hinweise erkannt.</p>
+    {% endif %}
+
+    {% set confidence_notes = draft.listing.attributes.get('confidenceNotes', []) %}
+    {% if confidence_notes %}
+      <p><strong>Unsicherheiten:</strong></p>
+      <ul>
+        {% for item in confidence_notes %}
+          <li>{{ item }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% if draft.listing.description_html %}
+      <p><strong>Beschreibung:</strong></p>
+      <div>{{ draft.listing.description_html | safe }}</div>
     {% endif %}
   </article>
 </section>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -3,6 +3,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from app.core.config import get_settings
+from app.drafts.analysis import HeuristicDraftAnalysisService, apply_analysis_result
 from app.drafts.repository import DraftRepository
 from app.drafts.upload_service import DraftUploadService, UploadAsset, UploadValidationError
 
@@ -68,6 +69,7 @@ async def upload_draft(
     settings = get_settings()
     repository = DraftRepository(settings.database_path)
     service = DraftUploadService(settings.data_dir)
+    analysis_service = HeuristicDraftAnalysisService()
     form_values = {
         "notes": notes,
         "product_name": product_name,
@@ -93,6 +95,8 @@ async def upload_draft(
                 "hints": hints,
             },
         )
+        analysis = analysis_service.analyze(result.draft)
+        apply_analysis_result(result.draft, analysis)
     except UploadValidationError as exc:
         return templates.TemplateResponse(
             request,

--- a/tests/test_draft_analysis.py
+++ b/tests/test_draft_analysis.py
@@ -1,0 +1,78 @@
+from app.drafts.analysis import HeuristicDraftAnalysisService, apply_analysis_result
+from app.drafts.models import Draft, WorkflowStatus
+
+
+def build_draft(*, user_input: dict[str, str] | None = None, notes: str = "") -> Draft:
+    return Draft(
+        id="draft_test1234",
+        sku="OIN-TEST1234",
+        source={
+            "images": [
+                {
+                    "id": "img_1",
+                    "originalFilename": "front.jpg",
+                    "storagePath": "data/drafts/draft_test1234/images/normalized/01-normalized.jpg",
+                    "mimeType": "image/jpeg",
+                    "order": 1,
+                    "kind": "normalized",
+                }
+            ],
+            "notes": notes,
+            "userInput": user_input or {},
+        },
+    )
+
+
+def test_heuristic_analysis_maps_known_fields_into_listing():
+    service = HeuristicDraftAnalysisService()
+    draft = build_draft(
+        user_input={
+            "product_name": "Nintendo Switch",
+            "condition": "gebraucht",
+            "accessories": "Dock, Netzteil",
+            "hints": "kleiner Kratzer",
+        },
+        notes="Display funktioniert gut",
+    )
+
+    analysis = service.analyze(draft)
+
+    assert analysis.listing.title == "Nintendo Switch"
+    assert analysis.listing.condition == "gebraucht"
+    assert analysis.listing.included_items == ["Dock", "Netzteil"]
+    assert analysis.listing.issues == ["kleiner Kratzer", "Display funktioniert gut"]
+    assert analysis.workflow_status == WorkflowStatus.CLASSIFIED
+    assert analysis.missing_information == []
+    assert "MVP-Heuristik" in analysis.confidence_notes[0]
+
+
+def test_heuristic_analysis_marks_missing_core_information():
+    service = HeuristicDraftAnalysisService()
+    draft = build_draft(user_input={"hints": "Funktionsstatus unklar"})
+
+    analysis = service.analyze(draft)
+
+    assert analysis.workflow_status == WorkflowStatus.NEEDS_ATTENTION
+    assert analysis.needs_review is True
+    assert "Produktname unklar" in analysis.missing_information
+    assert "Zustand fehlt" in analysis.missing_information
+    assert analysis.listing.title == ""
+    assert analysis.listing.condition == ""
+
+
+def test_apply_analysis_result_updates_draft_fields():
+    service = HeuristicDraftAnalysisService()
+    draft = build_draft(
+        user_input={
+            "product_name": "Kamera",
+            "hints": "Akku fehlt",
+        }
+    )
+
+    analysis = service.analyze(draft)
+    updated = apply_analysis_result(draft, analysis)
+
+    assert updated.listing.title == "Kamera"
+    assert updated.workflow.status == WorkflowStatus.NEEDS_ATTENTION
+    assert updated.workflow.missing_information == ["Zustand fehlt"]
+    assert "confidenceNotes" in updated.listing.attributes

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -59,6 +59,9 @@ def test_post_upload_creates_draft_and_files(client: TestClient):
 
     detail = client.get(location)
     assert detail.status_code == 200
+    assert "Deine Angaben" in detail.text
+    assert "Systemvorschlag" in detail.text
+    assert "Freitext-Notizen" in detail.text
     assert "Leichte Gebrauchsspuren" in detail.text
     assert "Testgerät" in detail.text
     assert "classified" in detail.text

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -61,6 +61,10 @@ def test_post_upload_creates_draft_and_files(client: TestClient):
     assert detail.status_code == 200
     assert "Leichte Gebrauchsspuren" in detail.text
     assert "Testgerät" in detail.text
+    assert "classified" in detail.text
+    assert "Netzteil" in detail.text
+    assert "Seriennummer verdeckt" in detail.text
+    assert "MVP-Heuristik" in detail.text
     assert "front.jpg" in detail.text
     assert "back.png" in detail.text
 


### PR DESCRIPTION
## Summary
- add a dedicated heuristic draft analysis service behind a reusable interface
- run analysis directly after upload and persist structured listing/workflow suggestions
- expose missing information, confidence notes, and generated draft details on the draft detail page
- add focused tests for the analysis service and upload flow integration

## Testing
- `.venv/bin/pytest -q`

## Follow-up
- Created follow-up issue #15 for the KI-/Vision-based analyzer implementation requested after this ticket.

Closes #6
