### PR TITLE
feat: add draft review and validation ui

### DIFF
--- a/app/drafts/analysis.py
+++ b/app/drafts/analysis.py
@@ -71,9 +71,12 @@ class HeuristicDraftAnalysisService:
             ),
         )
 
-        workflow_status = (
-            WorkflowStatus.NEEDS_ATTENTION if missing_information else WorkflowStatus.CLASSIFIED
-        )
+        if not draft.source.images or (not product_name and not notes):
+            workflow_status = WorkflowStatus.BLOCKED
+        elif missing_information:
+            workflow_status = WorkflowStatus.NEEDS_ATTENTION
+        else:
+            workflow_status = WorkflowStatus.READY_FOR_REVIEW
 
         return DraftAnalysisResult(
             listing=listing,

--- a/app/drafts/review.py
+++ b/app/drafts/review.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from app.drafts.analysis import _build_description_html, _collect_issues, _split_lines_or_csv
+from app.drafts.models import Draft, WorkflowStatus
+
+ReviewState = Literal["ready", "needs_attention", "blocked"]
+
+CORE_FIELDS: dict[str, str] = {
+    "title": "Titel / Produktname",
+    "condition": "Zustand",
+    "description_html": "Beschreibung",
+    "included_items": "Zubehör",
+}
+
+OPTIONAL_FIELDS: dict[str, str] = {
+    "brand": "Marke",
+    "model": "Modell",
+    "subtitle": "Untertitel",
+    "category_suggestion": "Kategorie-Vorschlag",
+}
+
+
+def evaluate_review_state(draft: Draft) -> ReviewState:
+    missing = get_missing_core_fields(draft)
+    if is_blocked(draft):
+        return "blocked"
+    if missing or get_confidence_notes(draft):
+        return "needs_attention"
+    return "ready"
+
+
+def get_missing_core_fields(draft: Draft) -> list[str]:
+    review = get_review_metadata(draft)
+    confirmed = {field for field in review.get("confirmedFields", []) if isinstance(field, str)}
+    missing: list[str] = []
+
+    checks = {
+        "title": draft.listing.title.strip(),
+        "condition": draft.listing.condition.strip(),
+        "description_html": _plain_description_text(draft).strip(),
+        "included_items": ", ".join(item.strip() for item in draft.listing.included_items if item.strip()),
+    }
+
+    for field, label in CORE_FIELDS.items():
+        if checks[field] or field in confirmed:
+            continue
+        missing.append(label)
+
+    return missing
+
+
+def get_confidence_notes(draft: Draft) -> list[str]:
+    notes = draft.listing.attributes.get("confidenceNotes", [])
+    return [note for note in notes if isinstance(note, str) and note.strip()]
+
+
+def get_review_metadata(draft: Draft) -> dict[str, Any]:
+    review = draft.listing.attributes.get("review")
+    return review if isinstance(review, dict) else {}
+
+
+def update_draft_from_review(
+    draft: Draft,
+    *,
+    title: str,
+    condition: str,
+    description: str,
+    included_items: str,
+    brand: str,
+    model: str,
+    subtitle: str,
+    category_suggestion: str,
+    hints: str,
+    confirm_fields: list[str],
+    action: str,
+) -> Draft:
+    draft.listing.title = title.strip()
+    draft.listing.condition = condition.strip()
+    draft.listing.brand = brand.strip()
+    draft.listing.model = model.strip()
+    draft.listing.subtitle = subtitle.strip()
+    draft.listing.category_suggestion = category_suggestion.strip()
+    draft.listing.included_items = _split_lines_or_csv(included_items)
+    draft.listing.issues = _collect_issues(hints)
+    draft.listing.description_html = _build_description_html(
+        product_name=draft.listing.title,
+        condition=draft.listing.condition,
+        accessories=draft.listing.included_items,
+        notes=description.strip(),
+        issues=draft.listing.issues,
+        missing_information=[],
+        confidence_notes=get_confidence_notes(draft),
+    )
+
+    draft.source.user_input.update(
+        {
+            "product_name": draft.listing.title,
+            "condition": draft.listing.condition,
+            "accessories": included_items.strip(),
+            "hints": hints.strip(),
+        }
+    )
+    draft.source.notes = description.strip()
+
+    missing = get_missing_core_fields(draft)
+    state = evaluate_review_state(draft)
+
+    review_metadata = {
+        "confirmedFields": sorted({field for field in confirm_fields if field in CORE_FIELDS}),
+        "reviewDecision": "confirmed" if action == "confirm" else "saved",
+        "reviewedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    draft.listing.attributes["review"] = review_metadata
+    draft.workflow.missing_information = missing
+
+    if action == "confirm" and state != "blocked":
+        draft.workflow.status = WorkflowStatus.READY_FOR_MARKETPLACE
+        draft.workflow.needs_review = False
+    elif state == "blocked":
+        draft.workflow.status = WorkflowStatus.BLOCKED
+        draft.workflow.needs_review = True
+    elif state == "needs_attention":
+        draft.workflow.status = WorkflowStatus.NEEDS_ATTENTION
+        draft.workflow.needs_review = True
+    else:
+        draft.workflow.status = WorkflowStatus.READY_FOR_REVIEW
+        draft.workflow.needs_review = True
+
+    return draft
+
+
+def is_blocked(draft: Draft) -> bool:
+    has_images = bool(draft.source.images)
+    has_title = bool(draft.listing.title.strip())
+    has_description = bool(_plain_description_text(draft).strip())
+    return not has_images or (not has_title and not has_description)
+
+
+def _plain_description_text(draft: Draft) -> str:
+    return draft.source.notes or ""

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -176,6 +176,14 @@ code {
   padding: 0.9rem 1rem;
   font: inherit;
   background: white;
+  color: var(--text);
+}
+
+.field input:focus,
+.field textarea:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.16);
+  outline-offset: 1px;
+  border-color: rgba(37, 99, 235, 0.55);
 }
 
 .field textarea {
@@ -190,6 +198,7 @@ code {
   border: 0;
   border-radius: 16px;
   padding: 0.95rem 1.15rem;
+  min-height: 3.25rem;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
@@ -200,6 +209,12 @@ code {
   background: var(--primary);
   color: white;
   margin-top: 1.2rem;
+}
+
+.button--secondary {
+  background: var(--surface-muted);
+  color: var(--text);
+  border: 1px solid rgba(117, 132, 168, 0.18);
 }
 
 .alert {
@@ -223,8 +238,101 @@ code {
   margin-top: 1.5rem;
 }
 
+.status-list {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.status-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background: var(--surface-muted);
+}
+
+.status-item span,
+.section-copy,
+.confirm-field,
+.review-panel__hint p {
+  color: var(--text-soft);
+}
+
+.review-panel {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.review-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.review-panel__hint {
+  max-width: 360px;
+  padding: 0.95rem 1rem;
+  border-radius: 20px;
+  background: var(--surface-muted);
+}
+
+.review-form,
+.action-card,
+.button-row {
+  display: grid;
+  gap: 1rem;
+}
+
+.field-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  vertical-align: middle;
+}
+
+.field-badge--required {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+
+.field-badge--optional {
+  background: rgba(23, 32, 51, 0.08);
+  color: var(--text-soft);
+}
+
+.confirm-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: -0.2rem 0 0.85rem;
+  font-size: 0.95rem;
+}
+
+.confirm-field input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.button-row {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.button-row .button {
+  width: 100%;
+  margin-top: 0;
+}
+
 @media (max-width: 900px) {
-  .upload-layout {
+  .upload-layout,
+  .button-row {
     grid-template-columns: 1fr;
   }
 }

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -4,83 +4,34 @@
 
 {% block content %}
 <section class="hero hero--compact">
-  <p class="eyebrow">Draft erstellt</p>
+  <p class="eyebrow">Nutzer-Review</p>
   <h1>{{ draft.id }}</h1>
   <p>SKU: <strong>{{ draft.sku }}</strong></p>
 </section>
 
 <section class="card-grid detail-grid">
   <article class="card">
-    <h2>Übersicht</h2>
+    <h2>Review-Zusammenfassung</h2>
     <ul>
       <li><strong>Workflow:</strong> {{ draft.workflow.status }}</li>
+      <li><strong>Review-Status:</strong> {{ review_state }}</li>
       <li><strong>Review nötig:</strong> {{ 'Ja' if draft.workflow.needs_review else 'Nein' }}</li>
       <li><strong>Bilder:</strong> {{ draft.source.images | length }}</li>
     </ul>
 
-    {% if draft.workflow.missing_information %}
-      <h3>Vor Review noch offen</h3>
+    {% if missing_core_fields %}
+      <h3>Fehlende Kernfelder</h3>
       <ul>
-        {% for item in draft.workflow.missing_information %}
+        {% for item in missing_core_fields %}
           <li>{{ item }}</li>
         {% endfor %}
       </ul>
     {% else %}
-      <p>Aktuell fehlen keine Pflichtangaben aus den vorhandenen Eingaben.</p>
-    {% endif %}
-  </article>
-
-  <article class="card">
-    <h2>Deine Angaben</h2>
-    <ul>
-      <li><strong>Produktname:</strong> {{ draft.source.user_input.get('product_name') or '–' }}</li>
-      <li><strong>Zustand:</strong> {{ draft.source.user_input.get('condition') or '–' }}</li>
-      <li><strong>Zubehör:</strong> {{ draft.source.user_input.get('accessories') or '–' }}</li>
-      <li><strong>Hinweise:</strong> {{ draft.source.user_input.get('hints') or '–' }}</li>
-    </ul>
-
-    {% if draft.source.notes %}
-      <p><strong>Freitext-Notizen:</strong><br>{{ draft.source.notes }}</p>
-    {% else %}
-      <p>Keine zusätzlichen Notizen hinterlegt.</p>
-    {% endif %}
-  </article>
-
-  <article class="card">
-    <h2>Systemvorschlag</h2>
-    <p>Das System leitet daraus einen ersten Entwurf ab. Das ist nur ein Vorschlag zur Prüfung.</p>
-
-    <ul>
-      <li><strong>Titel:</strong> {{ draft.listing.title or '–' }}</li>
-      <li><strong>Zustand:</strong> {{ draft.listing.condition or '–' }}</li>
-      <li><strong>Kategorie:</strong> {{ draft.listing.category_suggestion or '–' }}</li>
-    </ul>
-
-    <h3>Erkanntes Zubehör</h3>
-    {% if draft.listing.included_items %}
-      <ul>
-        {% for item in draft.listing.included_items %}
-          <li>{{ item }}</li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p>Kein Zubehör vorgeschlagen.</p>
+      <p>Alle Kernfelder sind vorhanden oder wurden bewusst bestätigt.</p>
     {% endif %}
 
-    <h3>Erkannte Hinweise</h3>
-    {% if draft.listing.issues %}
-      <ul>
-        {% for item in draft.listing.issues %}
-          <li>{{ item }}</li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p>Keine Hinweise erkannt.</p>
-    {% endif %}
-
-    {% set confidence_notes = draft.listing.attributes.get('confidenceNotes', []) %}
     {% if confidence_notes %}
-      <h3>Unsicherheiten des Vorschlags</h3>
+      <h3>Unsichere Angaben</h3>
       <ul>
         {% for item in confidence_notes %}
           <li>{{ item }}</li>
@@ -88,23 +39,90 @@
       </ul>
     {% endif %}
   </article>
+
+  <article class="card">
+    <h2>Bildprüfung</h2>
+    <p>Vorhandene normalisierte Arbeitskopien für die manuelle Sichtprüfung.</p>
+    <div class="preview-grid">
+      {% for image in draft.source.images %}
+        <article class="preview-card">
+          <img src="/{{ image.storage_path }}" alt="{{ image.original_filename }}">
+          <strong>{{ image.order }}. {{ image.original_filename }}</strong>
+          <span class="preview-meta">{{ image.mime_type }} · {{ image.kind }}</span>
+        </article>
+      {% endfor %}
+    </div>
+  </article>
 </section>
 
-<section class="panel image-list-panel">
+<section class="panel">
   <div>
-    <p class="eyebrow">Gespeicherte Bilder</p>
-    <h2>Normalisierte Arbeitskopien</h2>
+    <p class="eyebrow">Prüfen, korrigieren, bestätigen</p>
+    <h2>Review- und Validierungsmaske</h2>
+    <p>Bearbeite die Kernfelder, markiere bewusst bestätigte Lücken und speichere oder schließe die Nutzer-Review ab.</p>
   </div>
 
-  <div class="preview-grid">
-    {% for image in draft.source.images %}
-      <article class="preview-card">
-        <img src="/{{ image.storage_path }}" alt="{{ image.original_filename }}">
-        <strong>{{ image.order }}. {{ image.original_filename }}</strong>
-        <span class="preview-meta">{{ image.mime_type }} · {{ image.kind }}</span>
-        <code>{{ image.storage_path }}</code>
+  <form method="post" action="/drafts/{{ draft.id }}/review" class="stack-lg">
+    <section class="card-grid detail-grid">
+      <article class="card">
+        <h3>Kernfelder</h3>
+
+        <label for="title"><strong>{{ core_fields['title'] }}</strong></label>
+        <input id="title" name="title" type="text" value="{{ draft.listing.title }}">
+        <label><input type="checkbox" name="confirm_fields" value="title" {% if 'title' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
+
+        <label for="condition"><strong>{{ core_fields['condition'] }}</strong></label>
+        <input id="condition" name="condition" type="text" value="{{ draft.listing.condition }}">
+        <label><input type="checkbox" name="confirm_fields" value="condition" {% if 'condition' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
+
+        <label for="description"><strong>{{ core_fields['description_html'] }}</strong></label>
+        <textarea id="description" name="description" rows="6">{{ draft.source.notes }}</textarea>
+        <label><input type="checkbox" name="confirm_fields" value="description_html" {% if 'description_html' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
+
+        <label for="included_items"><strong>{{ core_fields['included_items'] }}</strong></label>
+        <textarea id="included_items" name="included_items" rows="4">{{ draft.source.user_input.get('accessories', '') }}</textarea>
+        <label><input type="checkbox" name="confirm_fields" value="included_items" {% if 'included_items' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
       </article>
-    {% endfor %}
-  </div>
+
+      <article class="card">
+        <h3>Optionale Felder</h3>
+
+        <label for="brand"><strong>{{ optional_fields['brand'] }}</strong></label>
+        <input id="brand" name="brand" type="text" value="{{ draft.listing.brand }}">
+
+        <label for="model"><strong>{{ optional_fields['model'] }}</strong></label>
+        <input id="model" name="model" type="text" value="{{ draft.listing.model }}">
+
+        <label for="subtitle"><strong>{{ optional_fields['subtitle'] }}</strong></label>
+        <input id="subtitle" name="subtitle" type="text" value="{{ draft.listing.subtitle }}">
+
+        <label for="category_suggestion"><strong>{{ optional_fields['category_suggestion'] }}</strong></label>
+        <input id="category_suggestion" name="category_suggestion" type="text" value="{{ draft.listing.category_suggestion }}">
+
+        <label for="hints"><strong>Hinweise / offene Punkte</strong></label>
+        <textarea id="hints" name="hints" rows="5">{{ draft.source.user_input.get('hints', '') }}</textarea>
+      </article>
+    </section>
+
+    <section class="card-grid detail-grid">
+      <article class="card">
+        <h3>Aktueller Systemvorschlag</h3>
+        <ul>
+          <li><strong>Titel:</strong> {{ draft.listing.title or '–' }}</li>
+          <li><strong>Zustand:</strong> {{ draft.listing.condition or '–' }}</li>
+          <li><strong>Kategorie:</strong> {{ draft.listing.category_suggestion or '–' }}</li>
+          <li><strong>Marke:</strong> {{ draft.listing.brand or '–' }}</li>
+          <li><strong>Modell:</strong> {{ draft.listing.model or '–' }}</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h3>Aktionen</h3>
+        <p>"Änderungen speichern" hält den Draft im Review-Flow. "Nutzer-Review abschließen" setzt den Draft bei ausreichender Freigabe auf <code>ready_for_marketplace</code>.</p>
+        <button type="submit" name="action" value="save">Änderungen speichern</button>
+        <button type="submit" name="action" value="confirm">Nutzer-Review abschließen</button>
+      </article>
+    </section>
+  </form>
 </section>
 {% endblock %}

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -12,12 +12,12 @@
 <section class="card-grid detail-grid">
   <article class="card">
     <h2>Review-Zusammenfassung</h2>
-    <ul>
-      <li><strong>Workflow:</strong> {{ draft.workflow.status }}</li>
-      <li><strong>Review-Status:</strong> {{ review_state }}</li>
-      <li><strong>Review nötig:</strong> {{ 'Ja' if draft.workflow.needs_review else 'Nein' }}</li>
-      <li><strong>Bilder:</strong> {{ draft.source.images | length }}</li>
-    </ul>
+    <div class="status-list">
+      <div class="status-item"><span>Workflow</span><strong>{{ draft.workflow.status }}</strong></div>
+      <div class="status-item"><span>Review-Status</span><strong>{{ review_state }}</strong></div>
+      <div class="status-item"><span>Review nötig</span><strong>{{ 'Ja' if draft.workflow.needs_review else 'Nein' }}</strong></div>
+      <div class="status-item"><span>Bilder</span><strong>{{ draft.source.images | length }}</strong></div>
+    </div>
 
     {% if missing_core_fields %}
       <h3>Fehlende Kernfelder</h3>
@@ -55,52 +55,86 @@
   </article>
 </section>
 
-<section class="panel">
-  <div>
-    <p class="eyebrow">Prüfen, korrigieren, bestätigen</p>
-    <h2>Review- und Validierungsmaske</h2>
-    <p>Bearbeite die Kernfelder, markiere bewusst bestätigte Lücken und speichere oder schließe die Nutzer-Review ab.</p>
+<section class="panel review-panel">
+  <div class="review-panel__header">
+    <div>
+      <p class="eyebrow">Prüfen, korrigieren, bestätigen</p>
+      <h2>Review- und Validierungsmaske</h2>
+      <p>Bearbeite die Kernfelder, ergänze sinnvolle optionale Angaben und bestätige nur bewusst leere Pflichtfelder.</p>
+    </div>
+    <div class="review-panel__hint">
+      <strong>Hinweis</strong>
+      <p><span class="field-badge field-badge--required">Pflicht / sinnvoll</span> sollte möglichst gesetzt werden. <span class="field-badge field-badge--optional">Optional</span> ergänzt nur bei Mehrwert.</p>
+    </div>
   </div>
 
-  <form method="post" action="/drafts/{{ draft.id }}/review" class="stack-lg">
-    <section class="card-grid detail-grid">
+  <form method="post" action="/drafts/{{ draft.id }}/review" class="stack-lg review-form">
+    <section class="card-grid detail-grid review-columns">
       <article class="card">
         <h3>Kernfelder</h3>
+        <p class="section-copy">Diese Angaben treiben den eigentlichen Listing-Entwurf. Fehlende Werte bitte ergänzen oder bewusst leer bestätigen.</p>
 
-        <label for="title"><strong>{{ core_fields['title'] }}</strong></label>
-        <input id="title" name="title" type="text" value="{{ draft.listing.title }}">
-        <label><input type="checkbox" name="confirm_fields" value="title" {% if 'title' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
+        <label class="field field--full" for="title">
+          <span>{{ core_fields['title'] }} <span class="field-badge field-badge--required">Pflicht / sinnvoll</span></span>
+          <input id="title" name="title" type="text" value="{{ draft.listing.title }}" placeholder="z. B. Nintendo Switch OLED">
+        </label>
+        {% if not draft.listing.title.strip() %}
+          <label class="confirm-field"><input type="checkbox" name="confirm_fields" value="title" {% if 'title' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Bewusst leer bestätigt</label>
+        {% endif %}
 
-        <label for="condition"><strong>{{ core_fields['condition'] }}</strong></label>
-        <input id="condition" name="condition" type="text" value="{{ draft.listing.condition }}">
-        <label><input type="checkbox" name="confirm_fields" value="condition" {% if 'condition' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
+        <label class="field field--full" for="condition">
+          <span>{{ core_fields['condition'] }} <span class="field-badge field-badge--required">Pflicht / sinnvoll</span></span>
+          <input id="condition" name="condition" type="text" value="{{ draft.listing.condition }}" placeholder="z. B. gebraucht, sehr gut">
+        </label>
+        {% if not draft.listing.condition.strip() %}
+          <label class="confirm-field"><input type="checkbox" name="confirm_fields" value="condition" {% if 'condition' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Bewusst leer bestätigt</label>
+        {% endif %}
 
-        <label for="description"><strong>{{ core_fields['description_html'] }}</strong></label>
-        <textarea id="description" name="description" rows="6">{{ draft.source.notes }}</textarea>
-        <label><input type="checkbox" name="confirm_fields" value="description_html" {% if 'description_html' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
+        <label class="field field--full" for="description">
+          <span>{{ core_fields['description_html'] }} <span class="field-badge field-badge--required">Pflicht / sinnvoll</span></span>
+          <textarea id="description" name="description" rows="6" placeholder="Kurz, klar, was ist es und in welchem Zustand?">{{ draft.source.notes }}</textarea>
+        </label>
+        {% if not draft.source.notes.strip() %}
+          <label class="confirm-field"><input type="checkbox" name="confirm_fields" value="description_html" {% if 'description_html' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Bewusst leer bestätigt</label>
+        {% endif %}
 
-        <label for="included_items"><strong>{{ core_fields['included_items'] }}</strong></label>
-        <textarea id="included_items" name="included_items" rows="4">{{ draft.source.user_input.get('accessories', '') }}</textarea>
-        <label><input type="checkbox" name="confirm_fields" value="included_items" {% if 'included_items' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Feld bewusst bestätigt</label>
+        <label class="field field--full" for="included_items">
+          <span>{{ core_fields['included_items'] }} <span class="field-badge field-badge--required">Pflicht / sinnvoll</span></span>
+          <textarea id="included_items" name="included_items" rows="4" placeholder="Je Zeile oder kommagetrennt, z. B. Dock, Netzteil, OVP">{{ draft.source.user_input.get('accessories', '') }}</textarea>
+        </label>
+        {% if not draft.listing.included_items %}
+          <label class="confirm-field"><input type="checkbox" name="confirm_fields" value="included_items" {% if 'included_items' in review_metadata.get('confirmedFields', []) %}checked{% endif %}> Bewusst leer bestätigt</label>
+        {% endif %}
       </article>
 
       <article class="card">
-        <h3>Optionale Felder</h3>
+        <h3>Ergänzende Angaben</h3>
+        <p class="section-copy">Optional, aber oft nützlich für bessere Qualität und weniger Nacharbeit.</p>
 
-        <label for="brand"><strong>{{ optional_fields['brand'] }}</strong></label>
-        <input id="brand" name="brand" type="text" value="{{ draft.listing.brand }}">
+        <label class="field field--full" for="brand">
+          <span>{{ optional_fields['brand'] }} <span class="field-badge field-badge--optional">Optional</span></span>
+          <input id="brand" name="brand" type="text" value="{{ draft.listing.brand }}" placeholder="z. B. Nintendo">
+        </label>
 
-        <label for="model"><strong>{{ optional_fields['model'] }}</strong></label>
-        <input id="model" name="model" type="text" value="{{ draft.listing.model }}">
+        <label class="field field--full" for="model">
+          <span>{{ optional_fields['model'] }} <span class="field-badge field-badge--optional">Optional</span></span>
+          <input id="model" name="model" type="text" value="{{ draft.listing.model }}" placeholder="z. B. OLED 64 GB">
+        </label>
 
-        <label for="subtitle"><strong>{{ optional_fields['subtitle'] }}</strong></label>
-        <input id="subtitle" name="subtitle" type="text" value="{{ draft.listing.subtitle }}">
+        <label class="field field--full" for="subtitle">
+          <span>{{ optional_fields['subtitle'] }} <span class="field-badge field-badge--optional">Optional</span></span>
+          <input id="subtitle" name="subtitle" type="text" value="{{ draft.listing.subtitle }}" placeholder="Kurze Zusatzinfo für das Listing">
+        </label>
 
-        <label for="category_suggestion"><strong>{{ optional_fields['category_suggestion'] }}</strong></label>
-        <input id="category_suggestion" name="category_suggestion" type="text" value="{{ draft.listing.category_suggestion }}">
+        <label class="field field--full" for="category_suggestion">
+          <span>{{ optional_fields['category_suggestion'] }} <span class="field-badge field-badge--optional">Optional</span></span>
+          <input id="category_suggestion" name="category_suggestion" type="text" value="{{ draft.listing.category_suggestion }}" placeholder="z. B. Konsolen">
+        </label>
 
-        <label for="hints"><strong>Hinweise / offene Punkte</strong></label>
-        <textarea id="hints" name="hints" rows="5">{{ draft.source.user_input.get('hints', '') }}</textarea>
+        <label class="field field--full" for="hints">
+          <span>Hinweise / offene Punkte <span class="field-badge field-badge--optional">Optional</span></span>
+          <textarea id="hints" name="hints" rows="5" placeholder="z. B. leichte Kratzer, Seriennummer verdeckt">{{ draft.source.user_input.get('hints', '') }}</textarea>
+        </label>
       </article>
     </section>
 
@@ -116,11 +150,13 @@
         </ul>
       </article>
 
-      <article class="card">
+      <article class="card action-card">
         <h3>Aktionen</h3>
-        <p>"Änderungen speichern" hält den Draft im Review-Flow. "Nutzer-Review abschließen" setzt den Draft bei ausreichender Freigabe auf <code>ready_for_marketplace</code>.</p>
-        <button type="submit" name="action" value="save">Änderungen speichern</button>
-        <button type="submit" name="action" value="confirm">Nutzer-Review abschließen</button>
+        <p>„Änderungen speichern“ hält den Draft im Review-Flow. „Nutzer-Review abschließen“ setzt den Draft bei ausreichender Freigabe auf <code>ready_for_marketplace</code>.</p>
+        <div class="button-row">
+          <button class="button button--secondary" type="submit" name="action" value="save">Änderungen speichern</button>
+          <button class="button button--primary" type="submit" name="action" value="confirm">Nutzer-Review abschließen</button>
+        </div>
       </article>
     </section>
   </form>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -5,6 +5,15 @@ from fastapi.templating import Jinja2Templates
 from app.core.config import get_settings
 from app.drafts.analysis import HeuristicDraftAnalysisService, apply_analysis_result
 from app.drafts.repository import DraftRepository
+from app.drafts.review import (
+    CORE_FIELDS,
+    OPTIONAL_FIELDS,
+    evaluate_review_state,
+    get_confidence_notes,
+    get_missing_core_fields,
+    get_review_metadata,
+    update_draft_from_review,
+)
 from app.drafts.upload_service import DraftUploadService, UploadAsset, UploadValidationError
 
 router = APIRouter()
@@ -123,5 +132,54 @@ def draft_detail(request: Request, draft_id: str):
     return templates.TemplateResponse(
         request,
         "draft_detail.html",
-        build_context(request, draft=draft),
+        build_context(
+            request,
+            draft=draft,
+            review_state=evaluate_review_state(draft),
+            missing_core_fields=get_missing_core_fields(draft),
+            confidence_notes=get_confidence_notes(draft),
+            review_metadata=get_review_metadata(draft),
+            core_fields=CORE_FIELDS,
+            optional_fields=OPTIONAL_FIELDS,
+        ),
     )
+
+
+@router.post("/drafts/{draft_id}/review", response_class=HTMLResponse)
+async def draft_review_submit(
+    request: Request,
+    draft_id: str,
+    title: str = Form(default=""),
+    condition: str = Form(default=""),
+    description: str = Form(default=""),
+    included_items: str = Form(default=""),
+    brand: str = Form(default=""),
+    model: str = Form(default=""),
+    subtitle: str = Form(default=""),
+    category_suggestion: str = Form(default=""),
+    hints: str = Form(default=""),
+    confirm_fields: list[str] = Form(default_factory=list),
+    action: str = Form(default="save"),
+):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    draft = repository.get_draft(draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    update_draft_from_review(
+        draft,
+        title=title,
+        condition=condition,
+        description=description,
+        included_items=included_items,
+        brand=brand,
+        model=model,
+        subtitle=subtitle,
+        category_suggestion=category_suggestion,
+        hints=hints,
+        confirm_fields=confirm_fields,
+        action=action,
+    )
+    repository.save_draft(draft)
+    return RedirectResponse(url=f"/drafts/{draft.id}", status_code=status.HTTP_303_SEE_OTHER)

--- a/tests/test_draft_analysis.py
+++ b/tests/test_draft_analysis.py
@@ -41,7 +41,7 @@ def test_heuristic_analysis_maps_known_fields_into_listing():
     assert analysis.listing.condition == "gebraucht"
     assert analysis.listing.included_items == ["Dock", "Netzteil"]
     assert analysis.listing.issues == ["kleiner Kratzer", "Display funktioniert gut"]
-    assert analysis.workflow_status == WorkflowStatus.CLASSIFIED
+    assert analysis.workflow_status == WorkflowStatus.READY_FOR_REVIEW
     assert analysis.missing_information == []
     assert "MVP-Heuristik" in analysis.confidence_notes[0]
 
@@ -52,7 +52,7 @@ def test_heuristic_analysis_marks_missing_core_information():
 
     analysis = service.analyze(draft)
 
-    assert analysis.workflow_status == WorkflowStatus.NEEDS_ATTENTION
+    assert analysis.workflow_status == WorkflowStatus.BLOCKED
     assert analysis.needs_review is True
     assert "Produktname unklar" in analysis.missing_information
     assert "Zustand fehlt" in analysis.missing_information

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -59,12 +59,10 @@ def test_post_upload_creates_draft_and_files(client: TestClient):
 
     detail = client.get(location)
     assert detail.status_code == 200
-    assert "Deine Angaben" in detail.text
-    assert "Systemvorschlag" in detail.text
-    assert "Freitext-Notizen" in detail.text
+    assert "Review- und Validierungsmaske" in detail.text
     assert "Leichte Gebrauchsspuren" in detail.text
     assert "Testgerät" in detail.text
-    assert "classified" in detail.text
+    assert "ready_for_review" in detail.text
     assert "Netzteil" in detail.text
     assert "Seriennummer verdeckt" in detail.text
     assert "MVP-Heuristik" in detail.text
@@ -105,3 +103,71 @@ def test_post_upload_rejects_too_small_images(client: TestClient):
 
     assert response.status_code == 400
     assert "mindestens 500px" in response.text
+
+
+def test_review_post_persists_changes_and_final_confirmation(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "Lampe", "condition": "gut", "notes": "Kleine Lampe", "accessories": "Kabel"},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+    detail = client.get(location)
+    assert "ready_for_review" in detail.text
+
+    review_response = client.post(
+        f"{location}/review",
+        data={
+            "title": "Lampe aus Metall",
+            "condition": "sehr gut",
+            "description": "Metalllampe, voll funktionsfähig",
+            "included_items": "Kabel, Schalter",
+            "brand": "NoName",
+            "model": "Desk 2000",
+            "subtitle": "Schreibtischlampe",
+            "category_suggestion": "Lampen",
+            "hints": "leichte Kratzer",
+            "confirm_fields": ["title", "condition", "description_html", "included_items"],
+            "action": "confirm",
+        },
+        follow_redirects=False,
+    )
+
+    assert review_response.status_code == 303
+
+    updated_detail = client.get(location)
+    assert "ready_for_marketplace" in updated_detail.text
+    assert "Lampe aus Metall" in updated_detail.text
+    assert "Desk 2000" in updated_detail.text
+    assert "Schreibtischlampe" in updated_detail.text
+
+
+def test_review_save_with_missing_core_fields_stays_in_needs_attention(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "", "condition": "", "notes": "", "accessories": ""},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+    review_response = client.post(
+        f"{location}/review",
+        data={
+            "title": "",
+            "condition": "",
+            "description": "Nur grob beschrieben",
+            "included_items": "",
+            "action": "save",
+        },
+        follow_redirects=False,
+    )
+
+    assert review_response.status_code == 303
+    updated_detail = client.get(location)
+    assert "needs_attention" in updated_detail.text
+    assert "Fehlende Kernfelder" in updated_detail.text


### PR DESCRIPTION
## Summary

Baut die bestehende Draft-Detailseite zur server-rendered Review-/Validierungsseite aus. Nutzer können Kernfelder prüfen, fehlende Angaben bewusst bestätigen, Änderungen speichern und die Nutzer-Review bis `ready_for_marketplace` abschließen.

## Changes

- neue Review-Logik in `app/drafts/review.py` für Kernfelder, Review-State (`ready` / `needs_attention` / `blocked`) und Workflow-Mapping
- Draft-Analyse setzt prüfbare Drafts jetzt direkt auf `ready_for_review` und erkennt harte Blocker als `blocked`
- `/drafts/{id}` zeigt jetzt Review-Zusammenfassung, Unsicherheiten, bearbeitbare Kern-/optionale Felder und Review-Aktionen
- neue POST-Route `/drafts/{id}/review` persistiert Änderungen und Nutzer-Bestätigungen
- Tests für den aktualisierten Flow und die Review-Aktionen ergänzt

## Testing

- `.venv/bin/pytest -q`

Fixes e-Luksch/open-inserto#7
