### PR TITLE
feat: add server-side listing description rendering

### DIFF
--- a/app/drafts/analysis.py
+++ b/app/drafts/analysis.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from html import escape
 from typing import Protocol
 
 from app.drafts.models import Draft, ListingData, WorkflowStatus
+from app.drafts.rendering import render_listing_description
 
 
 @dataclass(slots=True)
@@ -60,15 +60,7 @@ class HeuristicDraftAnalysisService:
             condition=condition,
             includedItems=accessories,
             issues=issues,
-            descriptionHtml=_build_description_html(
-                product_name=product_name,
-                condition=condition,
-                accessories=accessories,
-                notes=notes,
-                issues=issues,
-                missing_information=missing_information,
-                confidence_notes=confidence_notes,
-            ),
+            descriptionHtml="",
         )
 
         if not draft.source.images or (not product_name and not notes):
@@ -77,6 +69,10 @@ class HeuristicDraftAnalysisService:
             workflow_status = WorkflowStatus.NEEDS_ATTENTION
         else:
             workflow_status = WorkflowStatus.READY_FOR_REVIEW
+
+        rendered_draft = draft.model_copy(deep=True)
+        rendered_draft.listing = listing.model_copy(deep=True)
+        listing.description_html = render_listing_description(rendered_draft)
 
         return DraftAnalysisResult(
             listing=listing,
@@ -131,54 +127,3 @@ def _collect_issues(*values: object) -> list[str]:
             issues.append(item)
     return issues
 
-
-def _build_description_html(
-    *,
-    product_name: str,
-    condition: str,
-    accessories: list[str],
-    notes: str,
-    issues: list[str],
-    missing_information: list[str],
-    confidence_notes: list[str],
-) -> str:
-    sections: list[str] = []
-
-    title = product_name or "Unbenannter Artikel"
-    sections.append(f"<p><strong>{escape(title)}</strong></p>")
-
-    details: list[str] = []
-    if condition:
-        details.append(f"<li><strong>Zustand:</strong> {escape(condition)}</li>")
-    if accessories:
-        details.append(
-            "<li><strong>Zubehör:</strong> " + ", ".join(escape(item) for item in accessories) + "</li>"
-        )
-    if details:
-        sections.append("<ul>" + "".join(details) + "</ul>")
-
-    if notes:
-        sections.append(f"<p><strong>Notizen:</strong> {escape(notes)}</p>")
-
-    if issues:
-        sections.append(
-            "<p><strong>Hinweise / offene Punkte:</strong></p><ul>"
-            + "".join(f"<li>{escape(item)}</li>" for item in issues)
-            + "</ul>"
-        )
-
-    if missing_information:
-        sections.append(
-            "<p><strong>Fehlende Informationen:</strong></p><ul>"
-            + "".join(f"<li>{escape(item)}</li>" for item in missing_information)
-            + "</ul>"
-        )
-
-    if confidence_notes:
-        sections.append(
-            "<p><strong>Unsicherheiten:</strong></p><ul>"
-            + "".join(f"<li>{escape(item)}</li>" for item in confidence_notes)
-            + "</ul>"
-        )
-
-    return "".join(sections)

--- a/app/drafts/rendering.py
+++ b/app/drafts/rendering.py
@@ -33,14 +33,14 @@ def build_listing_render_context(draft: Draft) -> dict[str, Any]:
     issues = [item.strip() for item in draft.listing.issues if isinstance(item, str) and item.strip()]
 
     return {
-        "manufacturer": draft.listing.brand.strip(),
-        "product_name": draft.listing.title.strip(),
-        "subtitle": draft.listing.subtitle.strip(),
-        "condition": draft.listing.condition.strip(),
-        "model": draft.listing.model.strip(),
-        "purchase_date": _string_attribute(attributes, "purchase_date"),
+        "manufacturer": _render_text_paragraph(draft.listing.brand.strip()),
+        "product_name": _render_text_paragraph(draft.listing.title.strip() or "Unbenannter Artikel"),
+        "subtitle": _render_text_paragraph(draft.listing.subtitle.strip()),
+        "condition": _render_text_paragraph(draft.listing.condition.strip()),
+        "model": _render_text_paragraph(draft.listing.model.strip()),
+        "purchase_date": _render_text_paragraph(_string_attribute(attributes, "purchase_date")),
         "product_identifier_type": _string_attribute(attributes, "product_identifier_type"),
-        "product_identifier_value": _string_attribute(attributes, "product_identifier_value"),
+        "product_identifier_value": _render_text_paragraph(_string_attribute(attributes, "product_identifier_value")),
         "description_html": _render_description_html(draft.source.notes),
         "included_items_html": _render_list_html(included_items),
         "issues_html": _render_list_html(issues),
@@ -69,6 +69,13 @@ def _render_description_html(value: object) -> Markup:
         for segment in cleaned
     )
     return Markup(html)
+
+
+def _render_text_paragraph(value: object) -> Markup:
+    text = value.strip() if isinstance(value, str) else ""
+    if not text:
+        return Markup("")
+    return Markup(f"<p>{escape(text)}</p>")
 
 
 def _render_list_html(items: list[str]) -> Markup:

--- a/app/drafts/rendering.py
+++ b/app/drafts/rendering.py
@@ -75,5 +75,5 @@ def _render_list_html(items: list[str]) -> Markup:
     if not items:
         return Markup("")
 
-    html = "<ul>" + "".join(f"<li>{escape(item)}</li>" for item in items) + "</ul>"
+    html = "".join(f"<p>{escape(item)}</p>" for item in items)
     return Markup(html)

--- a/app/drafts/rendering.py
+++ b/app/drafts/rendering.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from html import escape
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from markupsafe import Markup
+
+from app.drafts.models import Draft
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
+_TEMPLATE_NAME = "listing_description.html"
+
+_environment = Environment(
+    loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+    autoescape=select_autoescape(enabled_extensions=("html", "xml"), default_for_string=True),
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+def render_listing_description(draft: Draft) -> str:
+    template = _environment.get_template(_TEMPLATE_NAME)
+    context = build_listing_render_context(draft)
+    return template.render(**context).strip()
+
+
+def build_listing_render_context(draft: Draft) -> dict[str, Any]:
+    attributes = draft.listing.attributes if isinstance(draft.listing.attributes, dict) else {}
+
+    included_items = [item.strip() for item in draft.listing.included_items if isinstance(item, str) and item.strip()]
+    issues = [item.strip() for item in draft.listing.issues if isinstance(item, str) and item.strip()]
+
+    return {
+        "manufacturer": draft.listing.brand.strip(),
+        "product_name": draft.listing.title.strip(),
+        "subtitle": draft.listing.subtitle.strip(),
+        "condition": draft.listing.condition.strip(),
+        "model": draft.listing.model.strip(),
+        "purchase_date": _string_attribute(attributes, "purchase_date"),
+        "product_identifier_type": _string_attribute(attributes, "product_identifier_type"),
+        "product_identifier_value": _string_attribute(attributes, "product_identifier_value"),
+        "description_html": _render_description_html(draft.source.notes),
+        "included_items_html": _render_list_html(included_items),
+        "issues_html": _render_list_html(issues),
+    }
+
+
+def _string_attribute(attributes: dict[str, Any], key: str) -> str:
+    value = attributes.get(key)
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _render_description_html(value: object) -> Markup:
+    text = value.strip() if isinstance(value, str) else ""
+    if not text:
+        return Markup("")
+
+    paragraphs = [segment.strip() for segment in text.replace("\r\n", "\n").split("\n\n")]
+    cleaned = [segment for segment in paragraphs if segment]
+    if not cleaned:
+        return Markup("")
+
+    html = "".join(
+        f"<p>{escape(segment).replace(chr(10), '<br>')}</p>"
+        for segment in cleaned
+    )
+    return Markup(html)
+
+
+def _render_list_html(items: list[str]) -> Markup:
+    if not items:
+        return Markup("")
+
+    html = "<ul>" + "".join(f"<li>{escape(item)}</li>" for item in items) + "</ul>"
+    return Markup(html)

--- a/app/drafts/review.py
+++ b/app/drafts/review.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from app.drafts.analysis import _build_description_html, _collect_issues, _split_lines_or_csv
+from app.drafts.analysis import _collect_issues, _split_lines_or_csv
 from app.drafts.models import Draft, WorkflowStatus
+from app.drafts.rendering import render_listing_description
 
 ReviewState = Literal["ready", "needs_attention", "blocked"]
 
@@ -85,15 +86,6 @@ def update_draft_from_review(
     draft.listing.category_suggestion = category_suggestion.strip()
     draft.listing.included_items = _split_lines_or_csv(included_items)
     draft.listing.issues = _collect_issues(hints)
-    draft.listing.description_html = _build_description_html(
-        product_name=draft.listing.title,
-        condition=draft.listing.condition,
-        accessories=draft.listing.included_items,
-        notes=description.strip(),
-        issues=draft.listing.issues,
-        missing_information=[],
-        confidence_notes=get_confidence_notes(draft),
-    )
 
     draft.source.user_input.update(
         {
@@ -104,6 +96,7 @@ def update_draft_from_review(
         }
     )
     draft.source.notes = description.strip()
+    draft.listing.description_html = render_listing_description(draft)
 
     missing = get_missing_core_fields(draft)
     state = evaluate_review_state(draft)

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -196,13 +196,41 @@ code {
   align-items: center;
   justify-content: center;
   border: 0;
-  border-radius: 16px;
-  padding: 0.8rem 1rem;
-  min-height: 2.85rem;
+  border-radius: 14px;
+  padding: 0.68rem 0.95rem;
+  min-height: 2.5rem;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
   text-decoration: none;
+}
+
+.card h3:first-child,
+.card h2:first-child {
+  margin-top: 0;
+}
+
+.card ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.card li + li {
+  margin-top: 0.35rem;
+}
+
+.card details {
+  margin-top: 0.85rem;
+}
+
+.card details summary {
+  cursor: pointer;
+  color: var(--text-soft);
+  font-weight: 600;
+}
+
+.card code {
+  word-break: break-word;
 }
 
 .button--primary {
@@ -288,9 +316,31 @@ code {
   gap: 1rem;
 }
 
-.draft-detail-grid {
-  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1.7fr);
+.review-columns {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: start;
+}
+
+.review-columns > .card,
+.draft-detail-grid > .card {
+  min-width: 0;
+}
+
+.draft-detail-grid {
+  grid-template-columns: minmax(240px, 0.9fr) minmax(0, 1.6fr) minmax(240px, 0.9fr);
+  align-items: start;
+}
+
+.action-card {
+  align-content: start;
+}
+
+.action-card p {
+  margin-top: 0;
+}
+
+.action-card code {
+  white-space: normal;
 }
 
 .prose-preview,
@@ -304,6 +354,21 @@ code {
   border-radius: 18px;
   border: 1px solid rgba(117, 132, 168, 0.18);
   background: #fbfdff;
+}
+
+.prose-preview--listing table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.prose-preview--listing td {
+  min-width: 0;
+  word-break: break-word;
+}
+
+.prose-preview--listing td:first-child {
+  width: 180px;
 }
 
 .prose-preview--listing p {
@@ -364,7 +429,18 @@ code {
   margin-top: 0;
 }
 
+@media (max-width: 1180px) {
+  .draft-detail-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .draft-detail-grid .action-card {
+    grid-column: 1 / -1;
+  }
+}
+
 @media (max-width: 980px) {
+  .review-columns,
   .draft-detail-grid {
     grid-template-columns: 1fr;
   }
@@ -374,5 +450,9 @@ code {
   .upload-layout,
   .button-row {
     grid-template-columns: 1fr;
+  }
+
+  .prose-preview--listing td:first-child {
+    width: 140px;
   }
 }

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -197,8 +197,8 @@ code {
   justify-content: center;
   border: 0;
   border-radius: 16px;
-  padding: 0.95rem 1.15rem;
-  min-height: 3.25rem;
+  padding: 0.8rem 1rem;
+  min-height: 2.85rem;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
@@ -288,6 +288,40 @@ code {
   gap: 1rem;
 }
 
+.draft-detail-grid {
+  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1.7fr);
+  align-items: start;
+}
+
+.prose-preview,
+.code-block {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.prose-preview--listing {
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(117, 132, 168, 0.18);
+  background: #fbfdff;
+}
+
+.prose-preview--listing p {
+  margin: 0 0 0.65rem;
+}
+
+.prose-preview--listing p:last-child {
+  margin-bottom: 0;
+}
+
+.code-block {
+  margin: 0.75rem 0 0;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
 .field-badge {
   display: inline-flex;
   align-items: center;
@@ -328,6 +362,12 @@ code {
 .button-row .button {
   width: 100%;
   margin-top: 0;
+}
+
+@media (max-width: 980px) {
+  .draft-detail-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 900px) {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -138,7 +138,7 @@
       </article>
     </section>
 
-    <section class="card-grid detail-grid">
+    <section class="card-grid detail-grid draft-detail-grid">
       <article class="card">
         <h3>Aktueller Systemvorschlag</h3>
         <ul>
@@ -155,10 +155,10 @@
         <p class="section-copy">Das HTML wird serverseitig aus den aktuellen Draft-Daten erzeugt, im Draft gespeichert und hier direkt als Vorschau angezeigt.</p>
         <p class="section-copy">So ist direkt sichtbar, wie die eBay-Beschreibung aktuell aussieht. Beim Speichern oder Bestätigen wird derselbe gerenderte Stand erneut persistiert.</p>
         {% if draft.listing.description_html %}
-          <div class="prose-preview">{{ draft.listing.description_html | safe }}</div>
+          <div class="prose-preview prose-preview--listing">{{ draft.listing.description_html | safe }}</div>
           <details>
             <summary>HTML-Quelltext anzeigen</summary>
-            <pre><code>{{ draft.listing.description_html }}</code></pre>
+            <pre class="code-block"><code>{{ draft.listing.description_html }}</code></pre>
           </details>
         {% else %}
           <p>Noch kein gerendertes HTML vorhanden.</p>

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -152,7 +152,8 @@
 
       <article class="card">
         <h3>Gerendertes Listing-HTML</h3>
-        <p class="section-copy">Das HTML wird serverseitig aus den aktuellen Draft-Daten erzeugt und hier direkt als Vorschau angezeigt.</p>
+        <p class="section-copy">Das HTML wird serverseitig aus den aktuellen Draft-Daten erzeugt, im Draft gespeichert und hier direkt als Vorschau angezeigt.</p>
+        <p class="section-copy">So ist direkt sichtbar, wie die eBay-Beschreibung aktuell aussieht. Beim Speichern oder Bestätigen wird derselbe gerenderte Stand erneut persistiert.</p>
         {% if draft.listing.description_html %}
           <div class="prose-preview">{{ draft.listing.description_html | safe }}</div>
           <details>

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -150,6 +150,20 @@
         </ul>
       </article>
 
+      <article class="card">
+        <h3>Gerendertes Listing-HTML</h3>
+        <p class="section-copy">Das HTML wird serverseitig aus den aktuellen Draft-Daten erzeugt und hier direkt als Vorschau angezeigt.</p>
+        {% if draft.listing.description_html %}
+          <div class="prose-preview">{{ draft.listing.description_html | safe }}</div>
+          <details>
+            <summary>HTML-Quelltext anzeigen</summary>
+            <pre><code>{{ draft.listing.description_html }}</code></pre>
+          </details>
+        {% else %}
+          <p>Noch kein gerendertes HTML vorhanden.</p>
+        {% endif %}
+      </article>
+
       <article class="card action-card">
         <h3>Aktionen</h3>
         <p>„Änderungen speichern“ hält den Draft im Review-Flow. „Nutzer-Review abschließen“ setzt den Draft bei ausreichender Freigabe auf <code>ready_for_marketplace</code>.</p>

--- a/app/templates/listing_description.html
+++ b/app/templates/listing_description.html
@@ -5,19 +5,27 @@
   Der Käufer trägt den Kaufpreis und die Versandkosten.
 </p>
 
-{% macro spacer() -%}
+{% macro spacer(count=1) -%}
+{% for _ in range(count) -%}
 <p>&nbsp;</p>
+{% endfor -%}
 {%- endmacro %}
 
-{% if manufacturer %}
 {{ spacer() }}
+{% if manufacturer %}
 <p><strong>Hersteller:</strong></p>
 <p>{{ manufacturer }}</p>
+{{ spacer() }}
 {% endif %}
 
-{{ spacer() }}
 <p><strong>Produkt:</strong></p>
 <p>{{ product_name or 'Unbenannter Artikel' }}</p>
+
+{% if product_identifier_value %}
+{{ spacer() }}
+<p><strong>{{ product_identifier_type or 'Modell-Nummer' }}:</strong></p>
+<p>{{ product_identifier_value }}</p>
+{% endif %}
 
 {% if model %}
 {{ spacer() }}
@@ -31,12 +39,6 @@
 <p>{{ subtitle }}</p>
 {% endif %}
 
-{% if product_identifier_value %}
-{{ spacer() }}
-<p><strong>{{ product_identifier_type or 'Modell-Nummer' }}:</strong></p>
-<p>{{ product_identifier_value }}</p>
-{% endif %}
-
 {% if purchase_date %}
 {{ spacer() }}
 <p><strong>Kaufdatum:</strong></p>
@@ -44,25 +46,25 @@
 {% endif %}
 
 {% if condition %}
-{{ spacer() }}
+{{ spacer(2) }}
 <p><strong>Zustand:</strong></p>
 <p>{{ condition }}</p>
 {% endif %}
 
 {% if description_html %}
-{{ spacer() }}
+{{ spacer(2) }}
 <p><strong>Beschreibung:</strong></p>
 {{ description_html }}
 {% endif %}
 
 {% if included_items_html %}
-{{ spacer() }}
+{{ spacer(2) }}
 <p><strong>Lieferumfang:</strong></p>
 {{ included_items_html }}
 {% endif %}
 
 {% if issues_html %}
-{{ spacer() }}
+{{ spacer(2) }}
 <p><strong>Hinweise:</strong></p>
 {{ issues_html }}
 {% endif %}

--- a/app/templates/listing_description.html
+++ b/app/templates/listing_description.html
@@ -1,70 +1,71 @@
-<p><strong>Wichtiger Hinweis:</strong></p>
-<p>
+{% macro row_html(label, value_html) -%}
+<tr>
+  <td style="padding: 3px; vertical-align: top; width: 180px;">
+    <p><b>{{ label }}</b></p>
+  </td>
+  <td style="padding: 3px; vertical-align: top;">
+    {{ value_html | safe }}
+  </td>
+</tr>
+{%- endmacro %}
+
+{% macro spacer_row() -%}
+<tr>
+  <td style="padding: 3px; vertical-align: top;"><p>&nbsp;</p></td>
+  <td style="padding: 3px; vertical-align: top;"><p>&nbsp;</p></td>
+</tr>
+{%- endmacro %}
+
+<font rwr="1" size="4" style="font-family: Arial;">
+  <b>Wichtiger Hinweis:</b><br>
   Es handelt sich um einen Privatverkauf, Gewährleistung und Rücknahme sind ausgeschlossen.
   Der Verkauf findet daher unter Ausschluss jeglicher Sachmängelhaftung statt.
   Der Käufer trägt den Kaufpreis und die Versandkosten.
-</p>
+  <br>
+  <br>
+  <table>
+    <tbody>
+      {% if manufacturer %}
+      {{ row_html('Hersteller:', manufacturer) }}
+      {% endif %}
 
-{% macro spacer(count=1) -%}
-{% for _ in range(count) -%}
-<p>&nbsp;</p>
-{% endfor -%}
-{%- endmacro %}
+      {{ row_html('Produkt:', product_name) }}
 
-{{ spacer() }}
-{% if manufacturer %}
-<p><strong>Hersteller:</strong></p>
-<p>{{ manufacturer }}</p>
-{{ spacer() }}
-{% endif %}
+      {% if product_identifier_value %}
+      {{ row_html((product_identifier_type or 'Modell-Nummer') ~ ':', product_identifier_value) }}
+      {% endif %}
 
-<p><strong>Produkt:</strong></p>
-<p>{{ product_name or 'Unbenannter Artikel' }}</p>
+      {% if model %}
+      {{ row_html('Modell:', model) }}
+      {% endif %}
 
-{% if product_identifier_value %}
-{{ spacer() }}
-<p><strong>{{ product_identifier_type or 'Modell-Nummer' }}:</strong></p>
-<p>{{ product_identifier_value }}</p>
-{% endif %}
+      {% if subtitle %}
+      {{ row_html('Untertitel:', subtitle) }}
+      {% endif %}
 
-{% if model %}
-{{ spacer() }}
-<p><strong>Modell:</strong></p>
-<p>{{ model }}</p>
-{% endif %}
+      {% if purchase_date %}
+      {{ row_html('Kaufdatum:', purchase_date) }}
+      {% endif %}
 
-{% if subtitle %}
-{{ spacer() }}
-<p><strong>Untertitel:</strong></p>
-<p>{{ subtitle }}</p>
-{% endif %}
+      {% if condition %}
+      {{ spacer_row() }}
+      {{ row_html('Zustand:', condition) }}
+      {% endif %}
 
-{% if purchase_date %}
-{{ spacer() }}
-<p><strong>Kaufdatum:</strong></p>
-<p>{{ purchase_date }}</p>
-{% endif %}
+      {% if description_html %}
+      {{ spacer_row() }}
+      {{ row_html('Beschreibung:', description_html) }}
+      {% endif %}
 
-{% if condition %}
-{{ spacer(2) }}
-<p><strong>Zustand:</strong></p>
-<p>{{ condition }}</p>
-{% endif %}
+      {% if included_items_html %}
+      {{ spacer_row() }}
+      {{ row_html('Lieferumfang:', included_items_html) }}
+      {% endif %}
 
-{% if description_html %}
-{{ spacer(2) }}
-<p><strong>Beschreibung:</strong></p>
-{{ description_html }}
-{% endif %}
-
-{% if included_items_html %}
-{{ spacer(2) }}
-<p><strong>Lieferumfang:</strong></p>
-{{ included_items_html }}
-{% endif %}
-
-{% if issues_html %}
-{{ spacer(2) }}
-<p><strong>Hinweise:</strong></p>
-{{ issues_html }}
-{% endif %}
+      {% if issues_html %}
+      {{ spacer_row() }}
+      {{ row_html('Hinweise:', issues_html) }}
+      {% endif %}
+    </tbody>
+  </table>
+</font>

--- a/app/templates/listing_description.html
+++ b/app/templates/listing_description.html
@@ -1,0 +1,42 @@
+<p><strong>{% if manufacturer %}{{ manufacturer }} {% endif %}{{ product_name or 'Unbenannter Artikel' }}</strong></p>
+{% if subtitle %}
+<p>{{ subtitle }}</p>
+{% endif %}
+
+{% if condition or model or purchase_date or product_identifier_value %}
+<ul>
+  {% if condition %}
+  <li><strong>Zustand:</strong> {{ condition }}</li>
+  {% endif %}
+  {% if model %}
+  <li><strong>Modell:</strong> {{ model }}</li>
+  {% endif %}
+  {% if purchase_date %}
+  <li><strong>Kaufdatum:</strong> {{ purchase_date }}</li>
+  {% endif %}
+  {% if product_identifier_value %}
+  <li><strong>{{ product_identifier_type or 'Produktkennung' }}:</strong> {{ product_identifier_value }}</li>
+  {% endif %}
+</ul>
+{% endif %}
+
+{% if description_html %}
+<div>
+  <strong>Beschreibung:</strong>
+  {{ description_html }}
+</div>
+{% endif %}
+
+{% if included_items_html %}
+<div>
+  <strong>Lieferumfang:</strong>
+  {{ included_items_html }}
+</div>
+{% endif %}
+
+{% if issues_html %}
+<div>
+  <strong>Hinweise:</strong>
+  {{ issues_html }}
+</div>
+{% endif %}

--- a/app/templates/listing_description.html
+++ b/app/templates/listing_description.html
@@ -1,42 +1,53 @@
-<p><strong>{% if manufacturer %}{{ manufacturer }} {% endif %}{{ product_name or 'Unbenannter Artikel' }}</strong></p>
-{% if subtitle %}
-<p>{{ subtitle }}</p>
+<p><strong>Wichtiger Hinweis:</strong></p>
+<p>
+  Es handelt sich um einen Privatverkauf, Gewährleistung und Rücknahme sind ausgeschlossen.
+  Der Verkauf findet daher unter Ausschluss jeglicher Sachmängelhaftung statt.
+  Der Käufer trägt den Kaufpreis und die Versandkosten.
+</p>
+
+{% if manufacturer %}
+<p><strong>Hersteller:</strong><br>{{ manufacturer }}</p>
 {% endif %}
 
-{% if condition or model or purchase_date or product_identifier_value %}
-<ul>
-  {% if condition %}
-  <li><strong>Zustand:</strong> {{ condition }}</li>
-  {% endif %}
-  {% if model %}
-  <li><strong>Modell:</strong> {{ model }}</li>
-  {% endif %}
-  {% if purchase_date %}
-  <li><strong>Kaufdatum:</strong> {{ purchase_date }}</li>
-  {% endif %}
-  {% if product_identifier_value %}
-  <li><strong>{{ product_identifier_type or 'Produktkennung' }}:</strong> {{ product_identifier_value }}</li>
-  {% endif %}
-</ul>
+<p><strong>Produkt:</strong><br>{{ product_name or 'Unbenannter Artikel' }}</p>
+
+{% if model %}
+<p><strong>Modell:</strong><br>{{ model }}</p>
+{% endif %}
+
+{% if subtitle %}
+<p><strong>Untertitel:</strong><br>{{ subtitle }}</p>
+{% endif %}
+
+{% if product_identifier_value %}
+<p><strong>{{ product_identifier_type or 'Modell-Nummer' }}:</strong><br>{{ product_identifier_value }}</p>
+{% endif %}
+
+{% if purchase_date %}
+<p><strong>Kaufdatum:</strong><br>{{ purchase_date }}</p>
+{% endif %}
+
+{% if condition %}
+<p><strong>Zustand:</strong><br>{{ condition }}</p>
 {% endif %}
 
 {% if description_html %}
 <div>
-  <strong>Beschreibung:</strong>
+  <p><strong>Beschreibung:</strong></p>
   {{ description_html }}
 </div>
 {% endif %}
 
 {% if included_items_html %}
 <div>
-  <strong>Lieferumfang:</strong>
+  <p><strong>Lieferumfang:</strong></p>
   {{ included_items_html }}
 </div>
 {% endif %}
 
 {% if issues_html %}
 <div>
-  <strong>Hinweise:</strong>
+  <p><strong>Hinweise:</strong></p>
   {{ issues_html }}
 </div>
 {% endif %}

--- a/app/templates/listing_description.html
+++ b/app/templates/listing_description.html
@@ -5,49 +5,64 @@
   Der Käufer trägt den Kaufpreis und die Versandkosten.
 </p>
 
+{% macro spacer() -%}
+<p>&nbsp;</p>
+{%- endmacro %}
+
 {% if manufacturer %}
-<p><strong>Hersteller:</strong><br>{{ manufacturer }}</p>
+{{ spacer() }}
+<p><strong>Hersteller:</strong></p>
+<p>{{ manufacturer }}</p>
 {% endif %}
 
-<p><strong>Produkt:</strong><br>{{ product_name or 'Unbenannter Artikel' }}</p>
+{{ spacer() }}
+<p><strong>Produkt:</strong></p>
+<p>{{ product_name or 'Unbenannter Artikel' }}</p>
 
 {% if model %}
-<p><strong>Modell:</strong><br>{{ model }}</p>
+{{ spacer() }}
+<p><strong>Modell:</strong></p>
+<p>{{ model }}</p>
 {% endif %}
 
 {% if subtitle %}
-<p><strong>Untertitel:</strong><br>{{ subtitle }}</p>
+{{ spacer() }}
+<p><strong>Untertitel:</strong></p>
+<p>{{ subtitle }}</p>
 {% endif %}
 
 {% if product_identifier_value %}
-<p><strong>{{ product_identifier_type or 'Modell-Nummer' }}:</strong><br>{{ product_identifier_value }}</p>
+{{ spacer() }}
+<p><strong>{{ product_identifier_type or 'Modell-Nummer' }}:</strong></p>
+<p>{{ product_identifier_value }}</p>
 {% endif %}
 
 {% if purchase_date %}
-<p><strong>Kaufdatum:</strong><br>{{ purchase_date }}</p>
+{{ spacer() }}
+<p><strong>Kaufdatum:</strong></p>
+<p>{{ purchase_date }}</p>
 {% endif %}
 
 {% if condition %}
-<p><strong>Zustand:</strong><br>{{ condition }}</p>
+{{ spacer() }}
+<p><strong>Zustand:</strong></p>
+<p>{{ condition }}</p>
 {% endif %}
 
 {% if description_html %}
-<div>
-  <p><strong>Beschreibung:</strong></p>
-  {{ description_html }}
-</div>
+{{ spacer() }}
+<p><strong>Beschreibung:</strong></p>
+{{ description_html }}
 {% endif %}
 
 {% if included_items_html %}
-<div>
-  <p><strong>Lieferumfang:</strong></p>
-  {{ included_items_html }}
-</div>
+{{ spacer() }}
+<p><strong>Lieferumfang:</strong></p>
+{{ included_items_html }}
 {% endif %}
 
 {% if issues_html %}
-<div>
-  <p><strong>Hinweise:</strong></p>
-  {{ issues_html }}
-</div>
+{{ spacer() }}
+<p><strong>Hinweise:</strong></p>
+{{ issues_html }}
 {% endif %}

--- a/tests/test_draft_rendering.py
+++ b/tests/test_draft_rendering.py
@@ -45,16 +45,21 @@ def test_render_listing_description_includes_expected_sections():
     html = render_listing_description(build_draft())
 
     assert "<strong>Wichtiger Hinweis:</strong>" in html
-    assert "<strong>Hersteller:</strong><br>Nintendo" in html
-    assert "<strong>Produkt:</strong><br>Switch OLED" in html
-    assert "<strong>Zustand:</strong><br>gebraucht" in html
-    assert "<strong>Kaufdatum:</strong><br>2024-12-24" in html
-    assert "<strong>Modell-Nummer:</strong><br>1234567890" in html
+    assert "<p><strong>Hersteller:</strong></p>" in html
+    assert "<p>Nintendo</p>" in html
+    assert "<p><strong>Produkt:</strong></p>" in html
+    assert "<p>Switch OLED</p>" in html
+    assert "<p><strong>Zustand:</strong></p>" in html
+    assert "<p>gebraucht</p>" in html
+    assert "<p><strong>Kaufdatum:</strong></p>" in html
+    assert "<p>2024-12-24</p>" in html
+    assert "<p><strong>Modell-Nummer:</strong></p>" in html
+    assert "<p>1234567890</p>" in html
     assert "<strong>Lieferumfang:</strong>" in html
-    assert "<li>Dock</li>" in html
-    assert "<li>Netzteil</li>" in html
+    assert "<p>Dock</p>" in html
+    assert "<p>Netzteil</p>" in html
     assert "<strong>Hinweise:</strong>" in html
-    assert "<li>kleiner Kratzer</li>" in html
+    assert "<p>kleiner Kratzer</p>" in html
 
 
 def test_render_listing_description_omits_empty_optional_blocks():
@@ -69,12 +74,14 @@ def test_render_listing_description_omits_empty_optional_blocks():
 
     html = render_listing_description(draft)
 
-    assert "<strong>Produkt:</strong><br>Switch OLED" in html
+    assert "<p><strong>Produkt:</strong></p>" in html
+    assert "<p>Switch OLED</p>" in html
     assert "Kaufdatum" not in html
     assert "Produktkennung" not in html
     assert "Lieferumfang" not in html
     assert "Hinweise" not in html
     assert "<ul>" not in html
+    assert "&nbsp;" in html
 
 
 def test_render_listing_description_escapes_user_text_and_preserves_structure():
@@ -96,7 +103,8 @@ def test_analysis_service_populates_rendered_description_html():
 
     analysis = service.analyze(draft)
 
-    assert "<strong>Produkt:</strong><br>Switch OLED" in analysis.listing.description_html
+    assert "<p><strong>Produkt:</strong></p>" in analysis.listing.description_html
+    assert "<p>Switch OLED</p>" in analysis.listing.description_html
     assert "<strong>Lieferumfang:</strong>" in analysis.listing.description_html
     assert "MVP-Heuristik" not in analysis.listing.description_html
 
@@ -119,9 +127,12 @@ def test_review_updates_rendered_description_html_from_current_draft_state():
         action="confirm",
     )
 
-    assert "<strong>Hersteller:</strong><br>Valve" in draft.listing.description_html
-    assert "<strong>Produkt:</strong><br>Steam Deck" in draft.listing.description_html
-    assert "<strong>Modell:</strong><br>OLED" in draft.listing.description_html
+    assert "<p><strong>Hersteller:</strong></p>" in draft.listing.description_html
+    assert "<p>Valve</p>" in draft.listing.description_html
+    assert "<p><strong>Produkt:</strong></p>" in draft.listing.description_html
+    assert "<p>Steam Deck</p>" in draft.listing.description_html
+    assert "<p><strong>Modell:</strong></p>" in draft.listing.description_html
+    assert "<p>OLED</p>" in draft.listing.description_html
     assert "<p>Portable Konsole</p>" in draft.listing.description_html
-    assert "<li>Case</li>" in draft.listing.description_html
-    assert "<li>Ladegerät</li>" in draft.listing.description_html
+    assert "<p>Case</p>" in draft.listing.description_html
+    assert "<p>Ladegerät</p>" in draft.listing.description_html

--- a/tests/test_draft_rendering.py
+++ b/tests/test_draft_rendering.py
@@ -44,10 +44,12 @@ def build_draft() -> Draft:
 def test_render_listing_description_includes_expected_sections():
     html = render_listing_description(build_draft())
 
-    assert "<strong>Nintendo Switch OLED</strong>" in html
-    assert "<strong>Zustand:</strong> gebraucht" in html
-    assert "<strong>Kaufdatum:</strong> 2024-12-24" in html
-    assert "<strong>Produktkennung:</strong> 1234567890" in html
+    assert "<strong>Wichtiger Hinweis:</strong>" in html
+    assert "<strong>Hersteller:</strong><br>Nintendo" in html
+    assert "<strong>Produkt:</strong><br>Switch OLED" in html
+    assert "<strong>Zustand:</strong><br>gebraucht" in html
+    assert "<strong>Kaufdatum:</strong><br>2024-12-24" in html
+    assert "<strong>Modell-Nummer:</strong><br>1234567890" in html
     assert "<strong>Lieferumfang:</strong>" in html
     assert "<li>Dock</li>" in html
     assert "<li>Netzteil</li>" in html
@@ -67,7 +69,7 @@ def test_render_listing_description_omits_empty_optional_blocks():
 
     html = render_listing_description(draft)
 
-    assert "<strong>Switch OLED</strong>" in html
+    assert "<strong>Produkt:</strong><br>Switch OLED" in html
     assert "Kaufdatum" not in html
     assert "Produktkennung" not in html
     assert "Lieferumfang" not in html
@@ -94,7 +96,7 @@ def test_analysis_service_populates_rendered_description_html():
 
     analysis = service.analyze(draft)
 
-    assert "<strong>Switch OLED</strong>" in analysis.listing.description_html
+    assert "<strong>Produkt:</strong><br>Switch OLED" in analysis.listing.description_html
     assert "<strong>Lieferumfang:</strong>" in analysis.listing.description_html
     assert "MVP-Heuristik" not in analysis.listing.description_html
 
@@ -117,8 +119,9 @@ def test_review_updates_rendered_description_html_from_current_draft_state():
         action="confirm",
     )
 
-    assert "<strong>Valve Steam Deck</strong>" in draft.listing.description_html
-    assert "<strong>Modell:</strong> OLED" in draft.listing.description_html
+    assert "<strong>Hersteller:</strong><br>Valve" in draft.listing.description_html
+    assert "<strong>Produkt:</strong><br>Steam Deck" in draft.listing.description_html
+    assert "<strong>Modell:</strong><br>OLED" in draft.listing.description_html
     assert "<p>Portable Konsole</p>" in draft.listing.description_html
     assert "<li>Case</li>" in draft.listing.description_html
     assert "<li>Ladegerät</li>" in draft.listing.description_html

--- a/tests/test_draft_rendering.py
+++ b/tests/test_draft_rendering.py
@@ -1,0 +1,124 @@
+from app.drafts.analysis import HeuristicDraftAnalysisService
+from app.drafts.models import Draft
+from app.drafts.rendering import render_listing_description
+from app.drafts.review import update_draft_from_review
+
+
+def build_draft() -> Draft:
+    return Draft(
+        id="draft_render1234",
+        sku="OIN-RENDER1234",
+        source={
+            "images": [
+                {
+                    "id": "img_1",
+                    "originalFilename": "front.jpg",
+                    "storagePath": "data/drafts/draft_render1234/images/normalized/01-normalized.jpg",
+                    "mimeType": "image/jpeg",
+                    "order": 1,
+                    "kind": "normalized",
+                }
+            ],
+            "notes": "Sauberer Zustand\n\nVoll funktionsfähig",
+            "userInput": {
+                "product_name": "Switch OLED",
+                "condition": "gebraucht",
+                "accessories": "Dock, Netzteil",
+                "hints": "kleiner Kratzer",
+            },
+        },
+        listing={
+            "title": "Switch OLED",
+            "brand": "Nintendo",
+            "condition": "gebraucht",
+            "includedItems": ["Dock", "Netzteil"],
+            "issues": ["kleiner Kratzer"],
+            "attributes": {
+                "purchase_date": "2024-12-24",
+                "product_identifier_value": "1234567890",
+            },
+        },
+    )
+
+
+def test_render_listing_description_includes_expected_sections():
+    html = render_listing_description(build_draft())
+
+    assert "<strong>Nintendo Switch OLED</strong>" in html
+    assert "<strong>Zustand:</strong> gebraucht" in html
+    assert "<strong>Kaufdatum:</strong> 2024-12-24" in html
+    assert "<strong>Produktkennung:</strong> 1234567890" in html
+    assert "<strong>Lieferumfang:</strong>" in html
+    assert "<li>Dock</li>" in html
+    assert "<li>Netzteil</li>" in html
+    assert "<strong>Hinweise:</strong>" in html
+    assert "<li>kleiner Kratzer</li>" in html
+
+
+def test_render_listing_description_omits_empty_optional_blocks():
+    draft = build_draft()
+    draft.listing.brand = ""
+    draft.listing.condition = ""
+    draft.listing.model = ""
+    draft.listing.included_items = []
+    draft.listing.issues = []
+    draft.listing.attributes = {}
+    draft.source.notes = ""
+
+    html = render_listing_description(draft)
+
+    assert "<strong>Switch OLED</strong>" in html
+    assert "Kaufdatum" not in html
+    assert "Produktkennung" not in html
+    assert "Lieferumfang" not in html
+    assert "Hinweise" not in html
+    assert "<ul>" not in html
+
+
+def test_render_listing_description_escapes_user_text_and_preserves_structure():
+    draft = build_draft()
+    draft.listing.title = "<Script-Konsole>"
+    draft.source.notes = "Zeile 1\nZeile 2 <b>unsafe</b>"
+    draft.listing.included_items = ["Dock <b>unsafe</b>"]
+
+    html = render_listing_description(draft)
+
+    assert "&lt;Script-Konsole&gt;" in html
+    assert "&lt;b&gt;unsafe&lt;/b&gt;" in html
+    assert "<script>" not in html.lower()
+
+
+def test_analysis_service_populates_rendered_description_html():
+    service = HeuristicDraftAnalysisService()
+    draft = build_draft()
+
+    analysis = service.analyze(draft)
+
+    assert "<strong>Switch OLED</strong>" in analysis.listing.description_html
+    assert "<strong>Lieferumfang:</strong>" in analysis.listing.description_html
+    assert "MVP-Heuristik" not in analysis.listing.description_html
+
+
+def test_review_updates_rendered_description_html_from_current_draft_state():
+    draft = build_draft()
+
+    update_draft_from_review(
+        draft,
+        title="Steam Deck",
+        condition="sehr gut",
+        description="Portable Konsole",
+        included_items="Case, Ladegerät",
+        brand="Valve",
+        model="OLED",
+        subtitle="512 GB",
+        category_suggestion="Gaming",
+        hints="leichte Gebrauchsspuren",
+        confirm_fields=["title", "condition", "description_html", "included_items"],
+        action="confirm",
+    )
+
+    assert "<strong>Valve Steam Deck</strong>" in draft.listing.description_html
+    assert "<strong>Modell:</strong> OLED" in draft.listing.description_html
+    assert "<p>Portable Konsole</p>" in draft.listing.description_html
+    assert "<li>Case</li>" in draft.listing.description_html
+    assert "<li>Ladegerät</li>" in draft.listing.description_html

--- a/tests/test_draft_rendering.py
+++ b/tests/test_draft_rendering.py
@@ -44,21 +44,22 @@ def build_draft() -> Draft:
 def test_render_listing_description_includes_expected_sections():
     html = render_listing_description(build_draft())
 
-    assert "<strong>Wichtiger Hinweis:</strong>" in html
-    assert "<p><strong>Hersteller:</strong></p>" in html
+    assert "<b>Wichtiger Hinweis:</b>" in html
+    assert "<table>" in html
+    assert "<b>Hersteller:</b>" in html
     assert "<p>Nintendo</p>" in html
-    assert "<p><strong>Produkt:</strong></p>" in html
+    assert "<b>Produkt:</b>" in html
     assert "<p>Switch OLED</p>" in html
-    assert "<p><strong>Zustand:</strong></p>" in html
+    assert "<b>Zustand:</b>" in html
     assert "<p>gebraucht</p>" in html
-    assert "<p><strong>Kaufdatum:</strong></p>" in html
+    assert "<b>Kaufdatum:</b>" in html
     assert "<p>2024-12-24</p>" in html
-    assert "<p><strong>Modell-Nummer:</strong></p>" in html
+    assert "<b>Modell-Nummer:</b>" in html
     assert "<p>1234567890</p>" in html
-    assert "<strong>Lieferumfang:</strong>" in html
+    assert "<b>Lieferumfang:</b>" in html
     assert "<p>Dock</p>" in html
     assert "<p>Netzteil</p>" in html
-    assert "<strong>Hinweise:</strong>" in html
+    assert "<b>Hinweise:</b>" in html
     assert "<p>kleiner Kratzer</p>" in html
 
 
@@ -74,14 +75,14 @@ def test_render_listing_description_omits_empty_optional_blocks():
 
     html = render_listing_description(draft)
 
-    assert "<p><strong>Produkt:</strong></p>" in html
+    assert "<b>Produkt:</b>" in html
     assert "<p>Switch OLED</p>" in html
     assert "Kaufdatum" not in html
     assert "Produktkennung" not in html
     assert "Lieferumfang" not in html
     assert "Hinweise" not in html
     assert "<ul>" not in html
-    assert "&nbsp;" in html
+    assert "<table>" in html
 
 
 def test_render_listing_description_escapes_user_text_and_preserves_structure():
@@ -103,9 +104,9 @@ def test_analysis_service_populates_rendered_description_html():
 
     analysis = service.analyze(draft)
 
-    assert "<p><strong>Produkt:</strong></p>" in analysis.listing.description_html
+    assert "<b>Produkt:</b>" in analysis.listing.description_html
     assert "<p>Switch OLED</p>" in analysis.listing.description_html
-    assert "<strong>Lieferumfang:</strong>" in analysis.listing.description_html
+    assert "<b>Lieferumfang:</b>" in analysis.listing.description_html
     assert "MVP-Heuristik" not in analysis.listing.description_html
 
 
@@ -127,11 +128,11 @@ def test_review_updates_rendered_description_html_from_current_draft_state():
         action="confirm",
     )
 
-    assert "<p><strong>Hersteller:</strong></p>" in draft.listing.description_html
+    assert "<b>Hersteller:</b>" in draft.listing.description_html
     assert "<p>Valve</p>" in draft.listing.description_html
-    assert "<p><strong>Produkt:</strong></p>" in draft.listing.description_html
+    assert "<b>Produkt:</b>" in draft.listing.description_html
     assert "<p>Steam Deck</p>" in draft.listing.description_html
-    assert "<p><strong>Modell:</strong></p>" in draft.listing.description_html
+    assert "<b>Modell:</b>" in draft.listing.description_html
     assert "<p>OLED</p>" in draft.listing.description_html
     assert "<p>Portable Konsole</p>" in draft.listing.description_html
     assert "<p>Case</p>" in draft.listing.description_html

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -147,7 +147,8 @@ def test_review_post_persists_changes_and_final_confirmation(client: TestClient)
     assert "Lampe aus Metall" in updated_detail.text
     assert "Desk 2000" in updated_detail.text
     assert "Schreibtischlampe" in updated_detail.text
-    assert "Hersteller:&lt;/strong&gt;&lt;/p&gt;\n&lt;p&gt;NoName" in updated_detail.text
+    assert "Hersteller:&lt;/b&gt;" in updated_detail.text
+    assert "NoName" in updated_detail.text
 
 
 def test_review_save_with_missing_core_fields_stays_in_needs_attention(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -65,6 +65,9 @@ def test_post_upload_creates_draft_and_files(client: TestClient):
     assert "ready_for_review" in detail.text
     assert "Netzteil" in detail.text
     assert "Seriennummer verdeckt" in detail.text
+    assert "Gerendertes Listing-HTML" in detail.text
+    assert "Das HTML wird serverseitig aus den aktuellen Draft-Daten erzeugt" in detail.text
+    assert "Wichtiger Hinweis:" in detail.text
     assert "MVP-Heuristik" in detail.text
     assert "front.jpg" in detail.text
     assert "back.png" in detail.text
@@ -143,6 +146,7 @@ def test_review_post_persists_changes_and_final_confirmation(client: TestClient)
     assert "Lampe aus Metall" in updated_detail.text
     assert "Desk 2000" in updated_detail.text
     assert "Schreibtischlampe" in updated_detail.text
+    assert "Hersteller:&lt;/strong&gt;&lt;br&gt;NoName" in updated_detail.text
 
 
 def test_review_save_with_missing_core_fields_stays_in_needs_attention(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -146,7 +146,7 @@ def test_review_post_persists_changes_and_final_confirmation(client: TestClient)
     assert "Lampe aus Metall" in updated_detail.text
     assert "Desk 2000" in updated_detail.text
     assert "Schreibtischlampe" in updated_detail.text
-    assert "Hersteller:&lt;/strong&gt;&lt;br&gt;NoName" in updated_detail.text
+    assert "Hersteller:&lt;/strong&gt;&lt;/p&gt;\n&lt;p&gt;NoName" in updated_detail.text
 
 
 def test_review_save_with_missing_core_fields_stays_in_needs_attention(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -66,7 +66,8 @@ def test_post_upload_creates_draft_and_files(client: TestClient):
     assert "Netzteil" in detail.text
     assert "Seriennummer verdeckt" in detail.text
     assert "Gerendertes Listing-HTML" in detail.text
-    assert "Das HTML wird serverseitig aus den aktuellen Draft-Daten erzeugt" in detail.text
+    assert "Das HTML wird serverseitig aus den aktuellen Draft-Daten erzeugt, im Draft gespeichert" in detail.text
+    assert "Beim Speichern oder Bestätigen wird derselbe gerenderte Stand erneut persistiert" in detail.text
     assert "Wichtiger Hinweis:" in detail.text
     assert "MVP-Heuristik" in detail.text
     assert "front.jpg" in detail.text


### PR DESCRIPTION
## Summary
- add a dedicated listing renderer and Jinja template for marketplace description HTML
- regenerate rendered HTML after analysis and review updates using draft data
- cover required, optional, escaping, and reproducibility cases with rendering tests

Closes #8