### PR TITLE
fix: simplify draft result and retry UX

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -460,6 +460,24 @@ code {
   margin-bottom: 1rem;
 }
 
+.detail-disclosure {
+  margin-top: 1rem;
+  border-radius: 20px;
+  background: rgba(31, 111, 95, 0.04);
+  border: 1px solid rgba(31, 111, 95, 0.08);
+  padding: 0.85rem 1rem;
+}
+
+.detail-disclosure summary {
+  cursor: pointer;
+  color: var(--text-soft);
+  font-weight: 700;
+}
+
+.detail-disclosure[open] summary {
+  margin-bottom: 0.8rem;
+}
+
 .alert {
   border-radius: 18px;
   padding: 1rem 1.2rem;

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -50,17 +50,10 @@
         </div>
       </div>
 
-      {% if show_technical_workflow_hint %}
-        <div class="notice notice--info">
-          <h3>Technischer Status</h3>
-          <p>Interner Workflow-Status: <strong>{{ draft.workflow.status }}</strong></p>
-          <p>Der technische Status dient nur der Systemdiagnose. Maßgeblich für den nächsten Schritt sind oben die Bereiche „Kernangaben“ und „eBay-Draft“.</p>
-        </div>
-      {% endif %}
-
       {% if missing_core_fields %}
         <div class="notice notice--warning">
-          <h3>Fehlende Kernfelder</h3>
+          <h3>Jetzt zuerst ergänzen</h3>
+          <p>Diese Kernfelder blockieren den nächsten sinnvollen Schritt und sollten vor dem Marketplace-Teil vervollständigt werden.</p>
           <ul>
             {% for item in missing_core_fields %}
               <li>{{ item }}</li>
@@ -73,15 +66,29 @@
         </div>
       {% endif %}
 
-      {% if confidence_notes %}
-        <div class="notice notice--info">
-          <h3>Unsichere Angaben</h3>
-          <ul>
-            {% for item in confidence_notes %}
-              <li>{{ item }}</li>
-            {% endfor %}
-          </ul>
-        </div>
+      {% if confidence_notes or show_technical_workflow_hint %}
+        <details class="detail-disclosure">
+          <summary>Diagnose und unsichere Angaben anzeigen</summary>
+
+          {% if confidence_notes %}
+            <div class="notice notice--info">
+              <h3>Unsichere Angaben</h3>
+              <ul>
+                {% for item in confidence_notes %}
+                  <li>{{ item }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+
+          {% if show_technical_workflow_hint %}
+            <div class="notice notice--info">
+              <h3>Technischer Status</h3>
+              <p>Interner Workflow-Status: <strong>{{ draft.workflow.status }}</strong></p>
+              <p>Der technische Status dient nur der Systemdiagnose. Maßgeblich für den nächsten Schritt sind oben die Bereiche „Kernangaben“ und „eBay-Draft“.</p>
+            </div>
+          {% endif %}
+        </details>
       {% endif %}
     </article>
 
@@ -110,7 +117,7 @@
       <div class="section-head">
         <div>
           <p class="eyebrow">Marketplace</p>
-          <h2>eBay-Status</h2>
+          <h2>Nächster eBay-Schritt</h2>
         </div>
         <div class="status-chip {% if not ebay_action_disabled and ebay_auth_connected %}status-chip--success{% else %}status-chip--muted{% endif %}">
           {{ marketplace_status_label }}
@@ -134,20 +141,24 @@
       {% endif %}
 
       {% if marketplace_notes %}
-        <div class="notice notice--info">
-          <h3>Hinweise zum eBay-Draft</h3>
-          <p>Diese Hinweise sind informativ und blockieren den eBay-Schritt nicht automatisch.</p>
-          <ul>
-            {% for item in marketplace_notes %}
-              <li>{{ item }}</li>
-            {% endfor %}
-          </ul>
-        </div>
+        <details class="detail-disclosure">
+          <summary>Hinweise zum eBay-Draft anzeigen</summary>
+          <div class="notice notice--info">
+            <h3>Hinweise zum eBay-Draft</h3>
+            <p>Diese Hinweise sind informativ und blockieren den eBay-Schritt nicht automatisch.</p>
+            <ul>
+              {% for item in marketplace_notes %}
+                <li>{{ item }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </details>
       {% endif %}
 
       {% if marketplace_readiness_errors %}
         <div class="notice notice--warning">
           <h3>Noch offen vor dem eBay-Schritt</h3>
+          <p>Solange diese Punkte offen sind, bleibt der eBay-Transfer deaktiviert.</p>
           <ul>
             {% for item in marketplace_readiness_errors %}
               <li>{{ item }}</li>
@@ -168,7 +179,7 @@
         <button class="button button--primary" type="submit" {% if ebay_action_disabled %}disabled{% endif %}>eBay-Draft senden</button>
       </form>
 
-      <details id="technical-details">
+      <details class="detail-disclosure" id="technical-details">
         <summary>Technische Details anzeigen</summary>
         <div class="default-grid default-grid--single">
           <div class="default-card"><span>Modus</span><strong>{{ ebay_mode }}</strong></div>

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -5,12 +5,13 @@
 {% block content %}
 <section class="hero hero--landing hero--detail">
   <div class="hero-landing__copy">
-    <p class="eyebrow">Nutzer-Review</p>
-    <h1>{{ draft.id }}</h1>
-    <p class="hero-lead">
-      Ein Draft, ein klarer Zustand: Review vervollständigen, eBay-Setup prüfen und erst dann sauber senden.
-    </p>
-    <p class="hero-support">SKU: <strong>{{ draft.sku }}</strong></p>
+    <p class="eyebrow">Ergebnis & nächster Schritt</p>
+    <h1>{{ result_summary.headline }}</h1>
+    <p class="hero-lead">{{ result_summary.body }}</p>
+    <p class="hero-support">Draft-ID: <strong>{{ draft.id }}</strong> · SKU: <strong>{{ draft.sku }}</strong></p>
+    <div class="hero-actions">
+      <a class="button button--primary" href="#{{ result_summary.primary_action_target }}">{{ result_summary.primary_action_label }}</a>
+    </div>
   </div>
 
   <aside class="hero-landing__panel">
@@ -38,7 +39,7 @@
 
 <section class="detail-shell">
   <section class="detail-main">
-    <article class="card card--config">
+    <article class="card card--config" id="review-form">
       <div class="section-head">
         <div>
           <p class="eyebrow">Reviewstatus</p>
@@ -115,16 +116,10 @@
           {{ marketplace_status_label }}
         </div>
       </div>
-      <div class="default-grid default-grid--single">
-        <div class="default-card"><span>Modus</span><strong>{{ ebay_mode }}</strong></div>
-        <div class="default-card"><span>Autorisierung</span><strong>{{ 'Verbunden' if ebay_auth_connected else 'Nicht verbunden' }}</strong></div>
-        <div class="default-card"><span>Merchant Location</span><strong>{{ ebay_effective_config.merchant_location_key or '–' }}</strong></div>
-        <div class="default-card"><span>Payment Policy</span><strong>{{ ebay_effective_config.payment_policy_id or '–' }}</strong></div>
-        <div class="default-card"><span>Fulfillment Policy</span><strong>{{ ebay_effective_config.fulfillment_policy_id or '–' }}</strong></div>
-        <div class="default-card"><span>Return Policy</span><strong>{{ ebay_effective_config.return_policy_id or '–' }}</strong></div>
-        <div class="default-card"><span>Inventory Item Key</span><strong>{{ draft.marketplace.ebay.inventory_item_key or '–' }}</strong></div>
-        <div class="default-card"><span>Offer ID</span><strong>{{ draft.marketplace.ebay.offer_id or '–' }}</strong></div>
-        <div class="default-card"><span>Bild-URLs</span><strong>{{ draft.marketplace.ebay.image_urls | length }}</strong></div>
+      <div class="notice {% if result_summary.tone == 'success' %}notice--success{% elif result_summary.tone == 'error' %}notice--error{% elif result_summary.tone == 'warning' %}notice--warning{% else %}notice--info{% endif %}">
+        <h3>Was gerade wichtig ist</h3>
+        <p><strong>{{ result_summary.headline }}</strong></p>
+        <p>{{ result_summary.body }}</p>
       </div>
 
       {% set ebay_error = draft.marketplace.ebay.offer_data.get('lastError') %}
@@ -162,16 +157,31 @@
       {% endif %}
 
       {% if not ebay_auth_connected %}
-        <form method="post" action="/integrations/ebay/connect" class="stack-md">
+        <form method="post" action="/integrations/ebay/connect" class="stack-md" id="ebay-connect">
           <p>Für den eBay-Draft wird eine gültige OAuth-Verbindung benötigt. Wenn die Verbindung abgelaufen oder ungültig ist, bitte hier erneut autorisieren.</p>
           <button class="button button--secondary" type="submit">eBay erneut verbinden</button>
         </form>
       {% endif %}
 
-      <form method="post" action="/drafts/{{ draft.id }}/marketplace/ebay" class="stack-md">
+      <form method="post" action="/drafts/{{ draft.id }}/marketplace/ebay" class="stack-md" id="ebay-send">
         <p>Erzeugt bzw. aktualisiert Inventory Item und ein unveröffentlichtes eBay-Offer. Nach einem eBay-Fehler kannst du den Schritt erneut ausführen, sobald die offenen Hinweise behoben sind.</p>
         <button class="button button--primary" type="submit" {% if ebay_action_disabled %}disabled{% endif %}>eBay-Draft senden</button>
       </form>
+
+      <details id="technical-details">
+        <summary>Technische Details anzeigen</summary>
+        <div class="default-grid default-grid--single">
+          <div class="default-card"><span>Modus</span><strong>{{ ebay_mode }}</strong></div>
+          <div class="default-card"><span>Autorisierung</span><strong>{{ 'Verbunden' if ebay_auth_connected else 'Nicht verbunden' }}</strong></div>
+          <div class="default-card"><span>Merchant Location</span><strong>{{ ebay_effective_config.merchant_location_key or '–' }}</strong></div>
+          <div class="default-card"><span>Payment Policy</span><strong>{{ ebay_effective_config.payment_policy_id or '–' }}</strong></div>
+          <div class="default-card"><span>Fulfillment Policy</span><strong>{{ ebay_effective_config.fulfillment_policy_id or '–' }}</strong></div>
+          <div class="default-card"><span>Return Policy</span><strong>{{ ebay_effective_config.return_policy_id or '–' }}</strong></div>
+          <div class="default-card"><span>Inventory Item Key</span><strong>{{ draft.marketplace.ebay.inventory_item_key or '–' }}</strong></div>
+          <div class="default-card"><span>Offer ID</span><strong>{{ draft.marketplace.ebay.offer_id or '–' }}</strong></div>
+          <div class="default-card"><span>Bild-URLs</span><strong>{{ draft.marketplace.ebay.image_urls | length }}</strong></div>
+        </div>
+      </details>
     </article>
   </aside>
 </section>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -57,6 +57,69 @@ def build_context(request: Request, **extra):
     return context
 
 
+def build_draft_result_summary(
+    *,
+    draft,
+    review_state: str,
+    ebay_auth_connected: bool,
+    marketplace_readiness_errors: list[str],
+) -> dict[str, object]:
+    ebay_error = str(draft.marketplace.ebay.offer_data.get("lastError") or "").strip()
+
+    if draft.marketplace.ebay.offer_id:
+        return {
+            "headline": "eBay-Draft erfolgreich erstellt",
+            "body": "Der Draft wurde an eBay übertragen. Wenn du magst, kannst du jetzt nur noch kurz die technischen Details prüfen.",
+            "tone": "success",
+            "primary_action_label": "Weiter prüfen",
+            "primary_action_target": "technical-details",
+        }
+
+    if not ebay_auth_connected:
+        return {
+            "headline": "eBay muss neu verbunden werden",
+            "body": "Die Verbindung zu eBay fehlt oder ist nicht mehr gültig. Danach kannst du den Draft direkt erneut senden.",
+            "tone": "warning",
+            "primary_action_label": "eBay erneut verbinden",
+            "primary_action_target": "ebay-connect",
+        }
+
+    if marketplace_readiness_errors:
+        return {
+            "headline": "Es fehlen noch Angaben",
+            "body": "Bevor der eBay-Schritt laufen kann, sollte der Draft noch an den markierten Punkten vervollständigt werden.",
+            "tone": "warning",
+            "primary_action_label": "Angaben ergänzen",
+            "primary_action_target": "review-form",
+        }
+
+    if ebay_error:
+        return {
+            "headline": "eBay hat den letzten Versuch abgelehnt",
+            "body": "Der lokale Draft ist erhalten geblieben. Du kannst den Schritt nach der kurzen Prüfung direkt erneut ausführen.",
+            "tone": "error",
+            "primary_action_label": "Erneut senden",
+            "primary_action_target": "ebay-send",
+        }
+
+    if review_state != "ready":
+        return {
+            "headline": "Bitte kurz prüfen",
+            "body": "Die Kernangaben sind noch nicht vollständig bestätigt. Danach kann der Marketplace-Schritt folgen.",
+            "tone": "info",
+            "primary_action_label": "Review öffnen",
+            "primary_action_target": "review-form",
+        }
+
+    return {
+        "headline": "Bereit für den nächsten Schritt",
+        "body": "Der Draft wirkt vollständig. Du kannst jetzt mit einem Klick den eBay-Draft anstoßen.",
+        "tone": "info",
+        "primary_action_label": "eBay-Draft senden",
+        "primary_action_target": "ebay-send",
+    }
+
+
 @router.get("/health")
 def health() -> dict[str, str]:
     settings = get_settings()
@@ -164,12 +227,22 @@ def draft_detail(request: Request, draft_id: str):
 
     review_state = evaluate_review_state(draft)
     review_status_label = "Review abgeschlossen" if not draft.workflow.needs_review else "Review noch offen"
-    if not marketplace_readiness_errors:
+    if draft.marketplace.ebay.offer_id:
+        marketplace_status_label = "Erfolgreich erstellt"
+    elif not marketplace_readiness_errors and draft.marketplace.ebay.offer_data.get("lastError"):
+        marketplace_status_label = "Retry möglich"
+    elif not marketplace_readiness_errors:
         marketplace_status_label = "Bereit für eBay-Draft"
     elif any("ist nicht konfiguriert" in item for item in marketplace_readiness_errors):
         marketplace_status_label = "Blockiert durch Konfiguration"
     else:
         marketplace_status_label = "Noch Angaben prüfen"
+    result_summary = build_draft_result_summary(
+        draft=draft,
+        review_state=review_state,
+        ebay_auth_connected=ebay_auth_connected,
+        marketplace_readiness_errors=marketplace_readiness_errors,
+    )
 
     return templates.TemplateResponse(
         request,
@@ -194,6 +267,7 @@ def draft_detail(request: Request, draft_id: str):
             core_fields=CORE_FIELDS,
             optional_fields=OPTIONAL_FIELDS,
             ebay_auth_connected=ebay_auth_connected,
+            result_summary=result_summary,
         ),
     )
 

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -8,7 +8,12 @@ from fastapi.testclient import TestClient
 from PIL import Image
 
 from app.core.config import get_settings
+from app.drafts.identity import derive_sku
+from app.drafts.models import Draft, WorkflowStatus
+from app.drafts.repository import DraftRepository
 from app.main import create_app
+from app.marketplaces.ebay.auth import EbayAuthStore, EbayTokenData
+from app.marketplaces.ebay.configuration import EbayConfigStore
 
 
 @pytest.fixture()
@@ -248,3 +253,105 @@ def test_draft_detail_blocks_non_numeric_ebay_category_id(client: TestClient):
     detail = client.get(location)
     assert "eBay-Kategorie muss als numerische Category ID angegeben werden" in detail.text
     assert '<button class="button button--primary" type="submit" disabled>eBay-Draft senden</button>' in detail.text
+
+
+def test_draft_detail_shows_primary_reconnect_action_when_auth_is_missing(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "Lampe", "condition": "gut", "notes": "Kleine Lampe", "accessories": "Kabel"},
+        follow_redirects=False,
+    )
+
+    detail = client.get(response.headers["location"])
+
+    assert "eBay muss neu verbunden werden" in detail.text
+    assert 'href="#ebay-connect"' in detail.text
+
+
+def test_draft_detail_shows_retry_result_for_retryable_ebay_error(client: TestClient):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    draft = Draft(
+        id="draft_retry_case",
+        sku=derive_sku("draft_retry_case"),
+        source={
+            "images": [{
+                "id": "img_01",
+                "originalFilename": "front.jpg",
+                "storagePath": "/data/test/front.jpg",
+                "mimeType": "image/jpeg",
+                "order": 1,
+                "kind": "original",
+            }],
+            "notes": "Kleine Lampe",
+        },
+        listing={
+            "title": "Lampe",
+            "descriptionHtml": "<p>Kleine Lampe</p>",
+            "condition": "gut",
+            "categorySuggestion": "123",
+        },
+    )
+    draft.workflow.status = WorkflowStatus.READY_FOR_MARKETPLACE
+    draft.workflow.needs_review = False
+    draft.marketplace.ebay.offer_data["lastError"] = "eBay timeout"
+    repository.save_draft(draft)
+
+    EbayAuthStore(settings.database_path).save_tokens(EbayTokenData(refresh_token="refresh-123"))
+    EbayConfigStore(settings.database_path).save_selected_configuration(
+        payment_policy_id="pay-1",
+        fulfillment_policy_id="ful-1",
+        return_policy_id="ret-1",
+        merchant_location_key="home",
+    )
+
+    detail = client.get(f"/drafts/{draft.id}")
+
+    assert "eBay hat den letzten Versuch abgelehnt" in detail.text
+    assert "Der lokale Draft ist erhalten geblieben" in detail.text
+    assert 'href="#ebay-send"' in detail.text
+
+
+def test_draft_detail_shows_success_result_with_technical_details_link(client: TestClient):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    draft = Draft(
+        id="draft_success_case",
+        sku=derive_sku("draft_success_case"),
+        source={
+            "images": [{
+                "id": "img_01",
+                "originalFilename": "front.jpg",
+                "storagePath": "/data/test/front.jpg",
+                "mimeType": "image/jpeg",
+                "order": 1,
+                "kind": "original",
+            }],
+        },
+        listing={
+            "title": "Lampe",
+            "descriptionHtml": "<p>Kleine Lampe</p>",
+            "condition": "gut",
+            "categorySuggestion": "123",
+        },
+    )
+    draft.workflow.status = WorkflowStatus.OFFER_CREATED
+    draft.workflow.needs_review = False
+    draft.marketplace.ebay.offer_id = "offer-123"
+    repository.save_draft(draft)
+
+    EbayAuthStore(settings.database_path).save_tokens(EbayTokenData(refresh_token="refresh-123"))
+    EbayConfigStore(settings.database_path).save_selected_configuration(
+        payment_policy_id="pay-1",
+        fulfillment_policy_id="ful-1",
+        return_policy_id="ret-1",
+        merchant_location_key="home",
+    )
+
+    detail = client.get(f"/drafts/{draft.id}")
+
+    assert "eBay-Draft erfolgreich erstellt" in detail.text
+    assert 'href="#technical-details"' in detail.text
+    assert "Technische Details anzeigen" in detail.text

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -199,7 +199,7 @@ def test_review_save_with_missing_core_fields_stays_in_needs_attention(client: T
     updated_detail = client.get(location)
     assert "needs_attention" in updated_detail.text
     assert "Kernangaben noch prüfen" in updated_detail.text
-    assert "Fehlende Kernfelder" in updated_detail.text
+    assert "Jetzt zuerst ergänzen" in updated_detail.text
     assert "Noch offen vor dem eBay-Schritt" in updated_detail.text
 
 


### PR DESCRIPTION
## Summary
- restore the missing eBay configuration store so master is runnable again
- replace the draft detail hero with a simple result/next-step card and primary action
- move technical IDs/config into a secondary details area and add regression tests for reconnect, retry, and success states

## Testing
- ./.venv/bin/pytest -q

Closes #10