### PR TITLE
feat: add draft overview page

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -65,6 +65,7 @@ body {
   color: white;
   position: relative;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .hero-landing__copy::after {
@@ -75,6 +76,8 @@ body {
   height: 18rem;
   border-radius: 50%;
   background: rgba(240, 215, 170, 0.18);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .hero-landing__panel {
@@ -109,6 +112,8 @@ body {
   gap: 0.75rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   margin-top: 1.25rem;
+  position: relative;
+  z-index: 1;
 }
 
 .hero-actions .button {
@@ -116,6 +121,8 @@ body {
   min-width: 0;
   margin-top: 0;
   text-align: center;
+  position: relative;
+  z-index: 1;
 }
 
 .hero-actions--split {
@@ -768,12 +775,23 @@ code {
 
 .draft-list-card h3,
 .draft-meta-list dd,
-.draft-meta-list dt {
+.draft-meta-list dt,
+.draft-list-card__support {
   margin: 0;
 }
 
 .draft-list-card h3 {
   overflow-wrap: anywhere;
+}
+
+.draft-list-card__intro {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.draft-list-card__support {
+  color: var(--text-soft);
+  font-size: 0.95rem;
 }
 
 .draft-list-card__top,
@@ -801,6 +819,10 @@ code {
   display: grid;
   gap: 0.8rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.draft-meta-list--compact {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .draft-meta-list div {

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -105,9 +105,21 @@ body {
 }
 
 .hero-actions {
-  display: flex;
+  display: grid;
   gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   margin-top: 1.25rem;
+}
+
+.hero-actions .button {
+  width: 100%;
+  min-width: 0;
+  margin-top: 0;
+  text-align: center;
+}
+
+.hero-actions--split {
+  max-width: 34rem;
 }
 
 .eyebrow {
@@ -313,6 +325,9 @@ code {
   font-weight: 700;
   cursor: pointer;
   text-decoration: none;
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .card h3:first-child,
@@ -757,12 +772,24 @@ code {
   margin: 0;
 }
 
+.draft-list-card h3 {
+  overflow-wrap: anywhere;
+}
+
 .draft-list-card__top,
 .draft-list-card__actions {
   display: flex;
   gap: 0.75rem;
   justify-content: space-between;
   align-items: flex-start;
+}
+
+.draft-list-card__top > * {
+  min-width: 0;
+}
+
+.draft-list-card__top .status-chip {
+  flex-shrink: 0;
 }
 
 .draft-list-card__actions .button {
@@ -827,7 +854,8 @@ code {
   .detail-shell,
   .upload-layout,
   .button-row,
-  .draft-meta-list {
+  .draft-meta-list,
+  .hero-actions {
     grid-template-columns: 1fr;
   }
 

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -767,19 +767,48 @@ code {
 
 .draft-list-card {
   display: grid;
-  gap: 0.8rem;
+  gap: 0.9rem;
   height: 100%;
-  padding: 1.1rem;
+  padding: 0.85rem;
   border-radius: 24px;
   border: 1px solid rgba(31, 42, 31, 0.08);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(249, 250, 248, 0.96));
   box-shadow: 0 16px 34px rgba(47, 55, 40, 0.07);
 }
 
+.draft-list-card__image {
+  display: block;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 18px;
+  background: rgba(222, 228, 217, 0.85);
+}
+
+.draft-list-card__image img,
+.draft-list-card__image-placeholder {
+  width: 100%;
+  height: 100%;
+}
+
+.draft-list-card__image img {
+  display: block;
+  object-fit: cover;
+}
+
+.draft-list-card__image-placeholder {
+  display: grid;
+  place-items: center;
+  color: var(--text-soft);
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(235, 239, 231, 0.95), rgba(247, 249, 245, 0.95));
+}
+
 .draft-list-card h3,
 .draft-list-card__meta dd,
 .draft-list-card__meta dt,
-.draft-list-card__support {
+.draft-list-card__support,
+.draft-list-card__subtitle,
+.draft-list-card__reference {
   margin: 0;
 }
 
@@ -791,13 +820,24 @@ code {
 
 .draft-list-card__intro {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.22rem;
   align-content: start;
 }
 
-.draft-list-card__support {
+.draft-list-card__subtitle {
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.draft-list-card__support,
+.draft-list-card__reference {
   color: var(--text-soft);
-  font-size: 0.9rem;
+  font-size: 0.86rem;
+}
+
+.draft-list-card__reference {
+  overflow-wrap: anywhere;
 }
 
 .draft-list-card__top,
@@ -808,7 +848,8 @@ code {
   align-items: center;
 }
 
-.draft-list-card__top > * {
+.draft-list-card__top > *,
+.draft-list-card__footer > * {
   min-width: 0;
 }
 
@@ -817,9 +858,9 @@ code {
 }
 
 .draft-list-card__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
   margin: 0;
   padding-top: 0.1rem;
 }
@@ -840,14 +881,6 @@ code {
   word-break: break-word;
 }
 
-.draft-list-card__meta code {
-  display: inline;
-  padding: 0;
-  background: transparent;
-  color: var(--text-soft);
-  font-size: 0.88rem;
-}
-
 .draft-list-card__footer {
   margin-top: auto;
   padding-top: 0.8rem;
@@ -855,13 +888,30 @@ code {
 }
 
 .draft-list-card__footer .button {
-  width: 100%;
+  width: auto;
+  min-width: 8.5rem;
   margin-top: 0;
   border-radius: 999px;
 }
 
 .draft-list-empty {
   margin-top: 0;
+}
+
+@media (hover: hover) {
+  .draft-list-card__image img {
+    transition: transform 180ms ease;
+  }
+
+  .draft-list-card:hover .draft-list-card__image img {
+    transform: scale(1.02);
+  }
+}
+
+@media (max-width: 640px) {
+  .draft-list-card__meta {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 1180px) {

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -760,27 +760,29 @@ code {
 
 .draft-list-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.4rem 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(285px, 1fr));
   align-items: stretch;
 }
 
 .draft-list-card {
   display: grid;
-  gap: 0.9rem;
+  gap: 0.8rem;
   height: 100%;
-  padding: 0.85rem;
-  border-radius: 24px;
-  border: 1px solid rgba(31, 42, 31, 0.08);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(249, 250, 248, 0.96));
-  box-shadow: 0 16px 34px rgba(47, 55, 40, 0.07);
+  padding: 0;
+  overflow: hidden;
+  border-radius: 28px;
+  border: 1px solid rgba(31, 42, 31, 0.06);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 20px 44px rgba(47, 55, 40, 0.08);
 }
 
 .draft-list-card__image {
   display: block;
+  position: relative;
   aspect-ratio: 4 / 3;
   overflow: hidden;
-  border-radius: 18px;
+  border-radius: 28px 28px 0 0;
   background: rgba(222, 228, 217, 0.85);
 }
 
@@ -793,6 +795,45 @@ code {
 .draft-list-card__image img {
   display: block;
   object-fit: cover;
+}
+
+.draft-list-card__status-badge {
+  position: absolute;
+  left: 1rem;
+  bottom: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  color: var(--text);
+  font-size: 0.88rem;
+  font-weight: 700;
+  box-shadow: 0 10px 22px rgba(21, 31, 21, 0.12);
+}
+
+.draft-list-card__status-badge::before {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.9;
+}
+
+.draft-list-card__status-badge--success {
+  color: var(--success);
+}
+
+.draft-list-card__status-badge--warning {
+  color: var(--warning);
+}
+
+.draft-list-card__status-badge--neutral {
+  color: #325f86;
 }
 
 .draft-list-card__image-placeholder {
@@ -814,20 +855,26 @@ code {
 
 .draft-list-card h3 {
   overflow-wrap: anywhere;
-  font-size: 1.08rem;
-  line-height: 1.3;
+  font-size: 1.18rem;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .draft-list-card__intro {
   display: grid;
-  gap: 0.22rem;
+  gap: 0.3rem;
   align-content: start;
+  padding: 0 1.2rem;
 }
 
 .draft-list-card__subtitle {
   color: var(--text);
-  font-size: 0.95rem;
+  font-size: 0.98rem;
   font-weight: 600;
+  min-height: 1.45rem;
 }
 
 .draft-list-card__support,
@@ -837,61 +884,42 @@ code {
 }
 
 .draft-list-card__reference {
+  font-size: 0.85rem;
+  font-weight: 500;
   overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  opacity: 0.78;
 }
 
-.draft-list-card__top,
 .draft-list-card__footer {
   display: flex;
   gap: 0.75rem;
   justify-content: space-between;
   align-items: center;
+  margin-top: auto;
+  padding: 0 1.2rem 1.2rem;
 }
 
-.draft-list-card__top > *,
 .draft-list-card__footer > * {
   min-width: 0;
 }
 
-.draft-list-card__top .status-chip {
-  flex-shrink: 0;
-}
-
-.draft-list-card__meta {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.7rem;
-  margin: 0;
-  padding-top: 0.1rem;
-}
-
-.draft-list-card__meta div {
-  min-width: 0;
-}
-
-.draft-list-card__meta dt {
-  color: var(--text-soft);
-  font-size: 0.78rem;
-  margin-bottom: 0.12rem;
-}
-
-.draft-list-card__meta dd {
-  font-size: 0.92rem;
-  font-weight: 600;
-  word-break: break-word;
-}
-
-.draft-list-card__footer {
-  margin-top: auto;
-  padding-top: 0.8rem;
-  border-top: 1px solid rgba(31, 42, 31, 0.08);
-}
-
-.draft-list-card__footer .button {
+.draft-list-card__action {
   width: auto;
-  min-width: 8.5rem;
+  min-width: 7.2rem;
   margin-top: 0;
   border-radius: 999px;
+  padding-inline: 1rem;
+  background: #f6f8f5;
+  border-color: rgba(31, 111, 95, 0.14);
+}
+
+.draft-list-card__action:hover,
+.draft-list-card__action:focus-visible {
+  background: #eef5f1;
 }
 
 .draft-list-empty {
@@ -899,18 +927,25 @@ code {
 }
 
 @media (hover: hover) {
+  .draft-list-card {
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      border-color 180ms ease;
+  }
+
   .draft-list-card__image img {
     transition: transform 180ms ease;
   }
 
-  .draft-list-card:hover .draft-list-card__image img {
-    transform: scale(1.02);
+  .draft-list-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 28px 54px rgba(47, 55, 40, 0.12);
+    border-color: rgba(31, 111, 95, 0.12);
   }
-}
 
-@media (max-width: 640px) {
-  .draft-list-card__meta {
-    grid-template-columns: 1fr;
+  .draft-list-card:hover .draft-list-card__image img {
+    transform: scale(1.04);
   }
 }
 
@@ -948,14 +983,16 @@ code {
     grid-template-columns: 1fr;
   }
 
-  .draft-list-card__top,
   .draft-list-card__footer {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .draft-list-card__top .status-chip {
-    align-self: flex-start;
+  .draft-list-card__status-badge {
+    left: 0.85rem;
+    right: 0.85rem;
+    bottom: 0.85rem;
+    justify-content: center;
   }
 
   .prose-preview--listing td:first-child {

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -762,15 +762,18 @@ code {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
 }
 
 .draft-list-card {
   display: grid;
   gap: 1rem;
+  height: 100%;
   padding: 1.2rem;
-  border-radius: 24px;
-  border: 1px solid var(--border);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(237, 241, 236, 0.9));
+  border-radius: 28px;
+  border: 1px solid rgba(31, 42, 31, 0.1);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 40px rgba(47, 55, 40, 0.08);
 }
 
 .draft-list-card h3,
@@ -782,16 +785,23 @@ code {
 
 .draft-list-card h3 {
   overflow-wrap: anywhere;
+  font-size: 1.2rem;
+  line-height: 1.3;
 }
 
 .draft-list-card__intro {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.4rem;
+  align-content: start;
 }
 
 .draft-list-card__support {
   color: var(--text-soft);
   font-size: 0.95rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .draft-list-card__top,
@@ -808,6 +818,10 @@ code {
 
 .draft-list-card__top .status-chip {
   flex-shrink: 0;
+}
+
+.draft-list-card__actions {
+  margin-top: auto;
 }
 
 .draft-list-card__actions .button {
@@ -832,6 +846,14 @@ code {
   border: 1px solid rgba(31, 111, 95, 0.08);
 }
 
+.draft-meta-list--airy {
+  gap: 0.65rem;
+}
+
+.draft-meta-list--airy div {
+  background: rgba(31, 111, 95, 0.04);
+}
+
 .draft-meta-list dt {
   color: var(--text-soft);
   font-size: 0.82rem;
@@ -841,6 +863,19 @@ code {
 .draft-meta-list dd {
   font-weight: 700;
   word-break: break-word;
+}
+
+.draft-meta-list--airy dd {
+  font-weight: 600;
+}
+
+.draft-meta-list--airy code {
+  display: inline-block;
+  padding: 0.18rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(31, 42, 31, 0.06);
+  color: var(--text-soft);
+  font-size: 0.84rem;
 }
 
 .draft-list-empty {

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -767,49 +767,45 @@ code {
 
 .draft-list-card {
   display: grid;
-  gap: 1rem;
+  gap: 0.8rem;
   height: 100%;
-  padding: 1.2rem;
-  border-radius: 28px;
-  border: 1px solid rgba(31, 42, 31, 0.1);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 18px 40px rgba(47, 55, 40, 0.08);
+  padding: 1.1rem;
+  border-radius: 24px;
+  border: 1px solid rgba(31, 42, 31, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(249, 250, 248, 0.96));
+  box-shadow: 0 16px 34px rgba(47, 55, 40, 0.07);
 }
 
 .draft-list-card h3,
-.draft-meta-list dd,
-.draft-meta-list dt,
+.draft-list-card__meta dd,
+.draft-list-card__meta dt,
 .draft-list-card__support {
   margin: 0;
 }
 
 .draft-list-card h3 {
   overflow-wrap: anywhere;
-  font-size: 1.2rem;
+  font-size: 1.08rem;
   line-height: 1.3;
 }
 
 .draft-list-card__intro {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.25rem;
   align-content: start;
 }
 
 .draft-list-card__support {
   color: var(--text-soft);
-  font-size: 0.95rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  font-size: 0.9rem;
 }
 
 .draft-list-card__top,
-.draft-list-card__actions {
+.draft-list-card__footer {
   display: flex;
   gap: 0.75rem;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .draft-list-card__top > * {
@@ -820,62 +816,48 @@ code {
   flex-shrink: 0;
 }
 
-.draft-list-card__actions {
-  margin-top: auto;
+.draft-list-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1rem;
+  margin: 0;
+  padding-top: 0.1rem;
 }
 
-.draft-list-card__actions .button {
-  width: 100%;
-  margin-top: 0;
+.draft-list-card__meta div {
+  min-width: 0;
 }
 
-.draft-meta-list {
-  display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.draft-meta-list--compact {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.draft-meta-list div {
-  padding: 0.85rem 0.9rem;
-  border-radius: 18px;
-  background: rgba(31, 111, 95, 0.06);
-  border: 1px solid rgba(31, 111, 95, 0.08);
-}
-
-.draft-meta-list--airy {
-  gap: 0.65rem;
-}
-
-.draft-meta-list--airy div {
-  background: rgba(31, 111, 95, 0.04);
-}
-
-.draft-meta-list dt {
+.draft-list-card__meta dt {
   color: var(--text-soft);
-  font-size: 0.82rem;
-  margin-bottom: 0.2rem;
+  font-size: 0.78rem;
+  margin-bottom: 0.12rem;
 }
 
-.draft-meta-list dd {
-  font-weight: 700;
+.draft-list-card__meta dd {
+  font-size: 0.92rem;
+  font-weight: 600;
   word-break: break-word;
 }
 
-.draft-meta-list--airy dd {
-  font-weight: 600;
+.draft-list-card__meta code {
+  display: inline;
+  padding: 0;
+  background: transparent;
+  color: var(--text-soft);
+  font-size: 0.88rem;
 }
 
-.draft-meta-list--airy code {
-  display: inline-block;
-  padding: 0.18rem 0.45rem;
+.draft-list-card__footer {
+  margin-top: auto;
+  padding-top: 0.8rem;
+  border-top: 1px solid rgba(31, 42, 31, 0.08);
+}
+
+.draft-list-card__footer .button {
+  width: 100%;
+  margin-top: 0;
   border-radius: 999px;
-  background: rgba(31, 42, 31, 0.06);
-  color: var(--text-soft);
-  font-size: 0.84rem;
 }
 
 .draft-list-empty {
@@ -917,9 +899,13 @@ code {
   }
 
   .draft-list-card__top,
-  .draft-list-card__actions {
+  .draft-list-card__footer {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .draft-list-card__top .status-chip {
+    align-self: flex-start;
   }
 
   .prose-preview--listing td:first-child {

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -731,6 +731,73 @@ code {
   background: var(--primary);
 }
 
+.draft-list-shell {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.draft-list-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.draft-list-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.2rem;
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(237, 241, 236, 0.9));
+}
+
+.draft-list-card h3,
+.draft-meta-list dd,
+.draft-meta-list dt {
+  margin: 0;
+}
+
+.draft-list-card__top,
+.draft-list-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.draft-list-card__actions .button {
+  width: 100%;
+  margin-top: 0;
+}
+
+.draft-meta-list {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.draft-meta-list div {
+  padding: 0.85rem 0.9rem;
+  border-radius: 18px;
+  background: rgba(31, 111, 95, 0.06);
+  border: 1px solid rgba(31, 111, 95, 0.08);
+}
+
+.draft-meta-list dt {
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  margin-bottom: 0.2rem;
+}
+
+.draft-meta-list dd {
+  font-weight: 700;
+  word-break: break-word;
+}
+
+.draft-list-empty {
+  margin-top: 0;
+}
+
 @media (max-width: 1180px) {
   .detail-shell {
     grid-template-columns: 1fr;
@@ -759,8 +826,15 @@ code {
   .default-grid,
   .detail-shell,
   .upload-layout,
-  .button-row {
+  .button-row,
+  .draft-meta-list {
     grid-template-columns: 1fr;
+  }
+
+  .draft-list-card__top,
+  .draft-list-card__actions {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .prose-preview--listing td:first-child {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -9,8 +9,9 @@
     <h1>{{ result_summary.headline }}</h1>
     <p class="hero-lead">{{ result_summary.body }}</p>
     <p class="hero-support">Draft-ID: <strong>{{ draft.id }}</strong> · SKU: <strong>{{ draft.sku }}</strong></p>
-    <div class="hero-actions">
+    <div class="hero-actions hero-actions--split">
       <a class="button button--primary" href="#{{ result_summary.primary_action_target }}">{{ result_summary.primary_action_label }}</a>
+      <a class="button button--secondary" href="/drafts">Zurück zur Übersicht</a>
     </div>
   </div>
 

--- a/app/templates/draft_list.html
+++ b/app/templates/draft_list.html
@@ -51,6 +51,14 @@
     <div class="draft-list-grid">
       {% for draft in drafts %}
         <article class="draft-list-card">
+          <a class="draft-list-card__image" href="{{ draft.detail_url }}" aria-label="{{ draft.title }} öffnen">
+            {% if draft.image_url %}
+              <img src="{{ draft.image_url }}" alt="{{ draft.image_alt }}">
+            {% else %}
+              <div class="draft-list-card__image-placeholder" aria-hidden="true">Kein Bild</div>
+            {% endif %}
+          </a>
+
           <div class="draft-list-card__top">
             <p class="eyebrow">Gespeicherter Entwurf</p>
             <span class="status-chip {% if draft.status.value in ['offer_created', 'published', 'ready_for_marketplace'] %}status-chip--success{% else %}status-chip--muted{% endif %}">
@@ -59,23 +67,25 @@
           </div>
 
           <div class="draft-list-card__intro">
-            <h3>SKU {{ draft.sku }}</h3>
+            <h3>{{ draft.title }}</h3>
+            <p class="draft-list-card__subtitle">{{ draft.subtitle }}</p>
             <p class="draft-list-card__support">Zuletzt bearbeitet am {{ draft.last_updated_at }}</p>
           </div>
 
           <dl class="draft-list-card__meta" aria-label="Draft-Metadaten">
             <div>
-              <dt>Erstellt</dt>
-              <dd>{{ draft.created_at }}</dd>
+              <dt>SKU</dt>
+              <dd>{{ draft.sku }}</dd>
             </div>
             <div>
-              <dt>Referenz</dt>
-              <dd><code>{{ draft.id }}</code></dd>
+              <dt>Erstellt</dt>
+              <dd>{{ draft.created_at }}</dd>
             </div>
           </dl>
 
           <div class="draft-list-card__footer">
-            <a class="button button--secondary" href="{{ draft.detail_url }}">Weiter bearbeiten</a>
+            <span class="draft-list-card__reference">Ref. {{ draft.id }}</span>
+            <a class="button button--secondary" href="{{ draft.detail_url }}">Öffnen</a>
           </div>
         </article>
       {% endfor %}

--- a/app/templates/draft_list.html
+++ b/app/templates/draft_list.html
@@ -23,16 +23,16 @@
     <p class="eyebrow">Übersicht</p>
     <div class="landing-metrics">
       <div class="landing-metric">
-        <span>Gesamt</span>
+        <span>Drafts gesamt</span>
         <strong>{{ drafts | length }}</strong>
       </div>
       <div class="landing-metric">
-        <span>Eintragstyp</span>
-        <strong>Server-rendered</strong>
+        <span>Sortierung</span>
+        <strong>Neueste zuerst</strong>
       </div>
       <div class="landing-metric landing-metric--wide">
-        <span>Nächster Schritt</span>
-        <strong>Draft öffnen und weiterbearbeiten</strong>
+        <span>Fokus</span>
+        <strong>Schnell wieder einsteigen und ohne Umwege weiterbearbeiten</strong>
       </div>
     </div>
   </aside>
@@ -57,14 +57,10 @@
             {% else %}
               <div class="draft-list-card__image-placeholder" aria-hidden="true">Kein Bild</div>
             {% endif %}
-          </a>
-
-          <div class="draft-list-card__top">
-            <p class="eyebrow">Gespeicherter Entwurf</p>
-            <span class="status-chip {% if draft.status.value in ['offer_created', 'published', 'ready_for_marketplace'] %}status-chip--success{% else %}status-chip--muted{% endif %}">
+            <span class="draft-list-card__status-badge {% if draft.status.value in ['offer_created', 'published'] %}draft-list-card__status-badge--success{% elif draft.status.value in ['needs_attention', 'blocked', 'error'] %}draft-list-card__status-badge--warning{% else %}draft-list-card__status-badge--neutral{% endif %}">
               {{ draft.status_label }}
             </span>
-          </div>
+          </a>
 
           <div class="draft-list-card__intro">
             <h3>{{ draft.title }}</h3>
@@ -72,20 +68,9 @@
             <p class="draft-list-card__support">Zuletzt bearbeitet am {{ draft.last_updated_at }}</p>
           </div>
 
-          <dl class="draft-list-card__meta" aria-label="Draft-Metadaten">
-            <div>
-              <dt>SKU</dt>
-              <dd>{{ draft.sku }}</dd>
-            </div>
-            <div>
-              <dt>Erstellt</dt>
-              <dd>{{ draft.created_at }}</dd>
-            </div>
-          </dl>
-
           <div class="draft-list-card__footer">
-            <span class="draft-list-card__reference">Ref. {{ draft.id }}</span>
-            <a class="button button--secondary" href="{{ draft.detail_url }}">Öffnen</a>
+            <span class="draft-list-card__reference">Entwurf ansehen</span>
+            <a class="button button--secondary draft-list-card__action" href="{{ draft.detail_url }}">Öffnen</a>
           </div>
         </article>
       {% endfor %}

--- a/app/templates/draft_list.html
+++ b/app/templates/draft_list.html
@@ -52,24 +52,25 @@
       {% for draft in drafts %}
         <article class="draft-list-card">
           <div class="draft-list-card__top">
-            <div class="draft-list-card__intro">
-              <p class="eyebrow">Gespeicherter Entwurf</p>
-              <h3>SKU {{ draft.sku }}</h3>
-              <p class="draft-list-card__support">Zuletzt bearbeitet am {{ draft.last_updated_at }}</p>
-            </div>
+            <p class="eyebrow">Gespeicherter Entwurf</p>
             <span class="status-chip {% if draft.status.value in ['offer_created', 'published', 'ready_for_marketplace'] %}status-chip--success{% else %}status-chip--muted{% endif %}">
               {{ draft.status_label }}
             </span>
           </div>
 
-          <dl class="draft-meta-list draft-meta-list--compact">
+          <div class="draft-list-card__intro">
+            <h3>SKU {{ draft.sku }}</h3>
+            <p class="draft-list-card__support">Zuletzt bearbeitet am {{ draft.last_updated_at }}</p>
+          </div>
+
+          <dl class="draft-meta-list draft-meta-list--compact draft-meta-list--airy">
             <div>
               <dt>Erstellt</dt>
               <dd>{{ draft.created_at }}</dd>
             </div>
             <div>
               <dt>Referenz</dt>
-              <dd>{{ draft.id }}</dd>
+              <dd><code>{{ draft.id }}</code></dd>
             </div>
           </dl>
 

--- a/app/templates/draft_list.html
+++ b/app/templates/draft_list.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} – Drafts{% endblock %}
+
+{% block content %}
+<section class="hero hero--landing hero--drafts">
+  <div class="hero-landing__copy">
+    <p class="eyebrow">Draft-Übersicht</p>
+    <h1>Vorhandene Drafts wiederfinden</h1>
+    <p class="hero-lead">
+      Alle gespeicherten Drafts an einem Ort, zuletzt bearbeitete zuerst.
+    </p>
+    <p class="hero-support">
+      Öffne bestehende Drafts direkt wieder, prüfe den Status und springe ohne Umwege zurück in die Detailansicht.
+    </p>
+
+    <div class="hero-actions">
+      <a class="button button--primary" href="/drafts/upload">Neuen Draft anlegen</a>
+    </div>
+  </div>
+
+  <aside class="hero-landing__panel">
+    <p class="eyebrow">Übersicht</p>
+    <div class="landing-metrics">
+      <div class="landing-metric">
+        <span>Gesamt</span>
+        <strong>{{ drafts | length }}</strong>
+      </div>
+      <div class="landing-metric">
+        <span>Eintragstyp</span>
+        <strong>Server-rendered</strong>
+      </div>
+      <div class="landing-metric landing-metric--wide">
+        <span>Nächster Schritt</span>
+        <strong>Draft öffnen und weiterbearbeiten</strong>
+      </div>
+    </div>
+  </aside>
+</section>
+
+<section class="card card--config draft-list-shell">
+  <div class="section-head">
+    <div>
+      <p class="eyebrow">Drafts</p>
+      <h2>Gespeicherte Entwürfe</h2>
+    </div>
+    <a class="button button--secondary" href="/">Zur Startseite</a>
+  </div>
+
+  {% if drafts %}
+    <div class="draft-list-grid">
+      {% for draft in drafts %}
+        <article class="draft-list-card">
+          <div class="draft-list-card__top">
+            <div>
+              <p class="eyebrow">{{ draft.sku }}</p>
+              <h3>{{ draft.id }}</h3>
+            </div>
+            <span class="status-chip {% if draft.status.value in ['offer_created', 'published', 'ready_for_marketplace'] %}status-chip--success{% else %}status-chip--muted{% endif %}">
+              {{ draft.status_label }}
+            </span>
+          </div>
+
+          <dl class="draft-meta-list">
+            <div>
+              <dt>Draft-ID</dt>
+              <dd>{{ draft.id }}</dd>
+            </div>
+            <div>
+              <dt>SKU</dt>
+              <dd>{{ draft.sku }}</dd>
+            </div>
+            <div>
+              <dt>Letzte Änderung</dt>
+              <dd>{{ draft.last_updated_at }}</dd>
+            </div>
+            <div>
+              <dt>Erstellt</dt>
+              <dd>{{ draft.created_at }}</dd>
+            </div>
+          </dl>
+
+          <div class="draft-list-card__actions">
+            <a class="button button--primary" href="{{ draft.detail_url }}">Draft öffnen</a>
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="notice notice--info draft-list-empty">
+      <h3>Noch keine Drafts vorhanden</h3>
+      <p>Lege zuerst einen neuen Draft an, dann erscheint er hier automatisch in der Übersicht.</p>
+      <a class="button button--primary" href="/drafts/upload">Zum Upload</a>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/draft_list.html
+++ b/app/templates/draft_list.html
@@ -52,36 +52,29 @@
       {% for draft in drafts %}
         <article class="draft-list-card">
           <div class="draft-list-card__top">
-            <div>
-              <p class="eyebrow">{{ draft.sku }}</p>
-              <h3>{{ draft.id }}</h3>
+            <div class="draft-list-card__intro">
+              <p class="eyebrow">Gespeicherter Entwurf</p>
+              <h3>SKU {{ draft.sku }}</h3>
+              <p class="draft-list-card__support">Zuletzt bearbeitet am {{ draft.last_updated_at }}</p>
             </div>
             <span class="status-chip {% if draft.status.value in ['offer_created', 'published', 'ready_for_marketplace'] %}status-chip--success{% else %}status-chip--muted{% endif %}">
               {{ draft.status_label }}
             </span>
           </div>
 
-          <dl class="draft-meta-list">
-            <div>
-              <dt>Draft-ID</dt>
-              <dd>{{ draft.id }}</dd>
-            </div>
-            <div>
-              <dt>SKU</dt>
-              <dd>{{ draft.sku }}</dd>
-            </div>
-            <div>
-              <dt>Letzte Änderung</dt>
-              <dd>{{ draft.last_updated_at }}</dd>
-            </div>
+          <dl class="draft-meta-list draft-meta-list--compact">
             <div>
               <dt>Erstellt</dt>
               <dd>{{ draft.created_at }}</dd>
             </div>
+            <div>
+              <dt>Referenz</dt>
+              <dd>{{ draft.id }}</dd>
+            </div>
           </dl>
 
           <div class="draft-list-card__actions">
-            <a class="button button--primary" href="{{ draft.detail_url }}">Draft öffnen</a>
+            <a class="button button--primary" href="{{ draft.detail_url }}">Weiter bearbeiten</a>
           </div>
         </article>
       {% endfor %}

--- a/app/templates/draft_list.html
+++ b/app/templates/draft_list.html
@@ -63,7 +63,7 @@
             <p class="draft-list-card__support">Zuletzt bearbeitet am {{ draft.last_updated_at }}</p>
           </div>
 
-          <dl class="draft-meta-list draft-meta-list--compact draft-meta-list--airy">
+          <dl class="draft-list-card__meta" aria-label="Draft-Metadaten">
             <div>
               <dt>Erstellt</dt>
               <dd>{{ draft.created_at }}</dd>
@@ -74,8 +74,8 @@
             </div>
           </dl>
 
-          <div class="draft-list-card__actions">
-            <a class="button button--primary" href="{{ draft.detail_url }}">Weiter bearbeiten</a>
+          <div class="draft-list-card__footer">
+            <a class="button button--secondary" href="{{ draft.detail_url }}">Weiter bearbeiten</a>
           </div>
         </article>
       {% endfor %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,6 +17,7 @@
 
     <div class="hero-actions">
       <a class="button button--primary" href="/drafts/upload">Zum Upload</a>
+      <a class="button button--secondary" href="/drafts">Drafts ansehen</a>
     </div>
   </div>
 

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -166,6 +166,10 @@ def draft_list(request: Request):
             "last_updated_at": draft.workflow.last_updated_at.strftime("%d.%m.%Y, %H:%M Uhr"),
             "created_at": draft.workflow.created_at.strftime("%d.%m.%Y, %H:%M Uhr"),
             "detail_url": f"/drafts/{draft.id}",
+            "title": draft.listing.title.strip() or f"SKU {draft.sku}",
+            "subtitle": draft.listing.subtitle.strip() or draft.listing.condition.strip() or "Entwurf bereit zum Weiterbearbeiten",
+            "image_url": f"/{draft.source.images[0].storage_path}" if draft.source.images else None,
+            "image_alt": draft.source.images[0].original_filename if draft.source.images else "Kein Vorschaubild vorhanden",
         }
         for draft in drafts
     ]

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -34,6 +34,19 @@ EXTRA_FIELDS = [
 ]
 
 
+STATUS_LABELS = {
+    WorkflowStatus.DRAFT: "Neu",
+    WorkflowStatus.CLASSIFIED: "Klassifiziert",
+    WorkflowStatus.NEEDS_ATTENTION: "Braucht Aufmerksamkeit",
+    WorkflowStatus.READY_FOR_REVIEW: "Bereit fürs Review",
+    WorkflowStatus.READY_FOR_MARKETPLACE: "Bereit für eBay",
+    WorkflowStatus.OFFER_CREATED: "eBay-Draft erstellt",
+    WorkflowStatus.PUBLISHED: "Veröffentlicht",
+    WorkflowStatus.BLOCKED: "Blockiert",
+    WorkflowStatus.ERROR: "Fehler",
+}
+
+
 def build_context(request: Request, **extra):
     settings = get_settings()
     auth_store = EbayAuthStore(settings.database_path)
@@ -133,6 +146,34 @@ def health() -> dict[str, str]:
 @router.get("/", response_class=HTMLResponse)
 def index(request: Request):
     return templates.TemplateResponse(request, "index.html", build_context(request))
+
+
+@router.get("/drafts", response_class=HTMLResponse)
+def draft_list(request: Request):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    drafts = sorted(
+        repository.list_drafts(),
+        key=lambda draft: draft.workflow.last_updated_at,
+        reverse=True,
+    )
+    draft_items = [
+        {
+            "id": draft.id,
+            "sku": draft.sku,
+            "status": draft.workflow.status,
+            "status_label": STATUS_LABELS.get(draft.workflow.status, draft.workflow.status.value),
+            "last_updated_at": draft.workflow.last_updated_at.strftime("%d.%m.%Y, %H:%M Uhr"),
+            "created_at": draft.workflow.created_at.strftime("%d.%m.%Y, %H:%M Uhr"),
+            "detail_url": f"/drafts/{draft.id}",
+        }
+        for draft in drafts
+    ]
+    return templates.TemplateResponse(
+        request,
+        "draft_list.html",
+        build_context(request, drafts=draft_items),
+    )
 
 
 @router.get("/drafts/upload", response_class=HTMLResponse)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -94,8 +94,11 @@ def test_draft_list_page_shows_existing_drafts_sorted_by_last_update(tmp_path: P
     assert response.status_code == 200
     assert "draft_old" in response.text
     assert "draft_new" in response.text
+    assert "SKU OIN-OLD" in response.text
+    assert "SKU OIN-NEW" in response.text
     assert 'href="/drafts/draft_old"' in response.text
     assert 'href="/drafts/draft_new"' in response.text
+    assert "Weiter bearbeiten" in response.text
     assert "Bereit für eBay" in response.text
     assert response.text.index("draft_new") < response.text.index("draft_old")
     get_settings.cache_clear()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.core.config import get_settings
+from app.drafts.models import Draft, WorkflowStatus
+from app.drafts.repository import DraftRepository
 from app.main import create_app
 
 
@@ -25,7 +27,78 @@ def test_index_page_renders():
     assert "Open Inserto" in response.text
     assert "MVP Upload Flow" in response.text
     assert "Zum Upload" in response.text
+    assert "Drafts ansehen" in response.text
     assert 'href="/drafts/upload"' in response.text
+    assert 'href="/drafts"' in response.text
+
+
+def test_draft_list_page_renders_empty_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'data' / 'test.db'}")
+    get_settings.cache_clear()
+
+    with TestClient(create_app()) as client:
+        response = client.get("/drafts")
+
+    assert response.status_code == 200
+    assert "Noch keine Drafts vorhanden" in response.text
+    assert 'href="/drafts/upload"' in response.text
+    get_settings.cache_clear()
+
+
+
+def test_draft_list_page_shows_existing_drafts_sorted_by_last_update(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'data' / 'test.db'}")
+    get_settings.cache_clear()
+
+    settings = get_settings()
+
+    with TestClient(create_app()):
+        pass
+
+    repository = DraftRepository(settings.database_path)
+
+    older = Draft.model_validate(
+        {
+            "id": "draft_old",
+            "sku": "OIN-OLD",
+            "workflow": {
+                "status": WorkflowStatus.READY_FOR_REVIEW,
+                "needsReview": True,
+                "createdAt": "2026-04-18T10:00:00+00:00",
+                "lastUpdatedAt": "2026-04-18T11:00:00+00:00",
+            },
+        }
+    )
+    newer = Draft.model_validate(
+        {
+            "id": "draft_new",
+            "sku": "OIN-NEW",
+            "workflow": {
+                "status": WorkflowStatus.READY_FOR_MARKETPLACE,
+                "needsReview": False,
+                "createdAt": "2026-04-19T10:00:00+00:00",
+                "lastUpdatedAt": "2026-04-19T12:30:00+00:00",
+            },
+        }
+    )
+    repository.create_draft(older)
+    repository.create_draft(newer)
+
+    with TestClient(create_app()) as client:
+        response = client.get("/drafts")
+
+    assert response.status_code == 200
+    assert "draft_old" in response.text
+    assert "draft_new" in response.text
+    assert 'href="/drafts/draft_old"' in response.text
+    assert 'href="/drafts/draft_new"' in response.text
+    assert "Bereit für eBay" in response.text
+    assert response.text.index("draft_new") < response.text.index("draft_old")
+    get_settings.cache_clear()
 
 
 def test_index_does_not_show_connected_for_env_token_fallbacks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -65,6 +65,22 @@ def test_draft_list_page_shows_existing_drafts_sorted_by_last_update(tmp_path: P
         {
             "id": "draft_old",
             "sku": "OIN-OLD",
+            "listing": {
+                "title": "Vintage Kamera",
+                "condition": "Gebraucht, guter Zustand",
+            },
+            "source": {
+                "images": [
+                    {
+                        "id": "img-old",
+                        "originalFilename": "kamera.jpg",
+                        "storagePath": "data/drafts/draft_old/images/normalized/01-normalized.jpg",
+                        "mimeType": "image/jpeg",
+                        "order": 1,
+                        "kind": "normalized",
+                    }
+                ]
+            },
             "workflow": {
                 "status": WorkflowStatus.READY_FOR_REVIEW,
                 "needsReview": True,
@@ -77,6 +93,10 @@ def test_draft_list_page_shows_existing_drafts_sorted_by_last_update(tmp_path: P
         {
             "id": "draft_new",
             "sku": "OIN-NEW",
+            "listing": {
+                "title": "Nintendo Switch OLED",
+                "subtitle": "Mit Dock und Netzteil",
+            },
             "workflow": {
                 "status": WorkflowStatus.READY_FOR_MARKETPLACE,
                 "needsReview": False,
@@ -94,11 +114,13 @@ def test_draft_list_page_shows_existing_drafts_sorted_by_last_update(tmp_path: P
     assert response.status_code == 200
     assert "draft_old" in response.text
     assert "draft_new" in response.text
-    assert "SKU OIN-OLD" in response.text
-    assert "SKU OIN-NEW" in response.text
+    assert "Vintage Kamera" in response.text
+    assert "Nintendo Switch OLED" in response.text
+    assert "Mit Dock und Netzteil" in response.text
+    assert "/data/drafts/draft_old/images/normalized/01-normalized.jpg" in response.text
     assert 'href="/drafts/draft_old"' in response.text
     assert 'href="/drafts/draft_new"' in response.text
-    assert "Weiter bearbeiten" in response.text
+    assert "Öffnen" in response.text
     assert "Bereit für eBay" in response.text
     assert response.text.index("draft_new") < response.text.index("draft_old")
     get_settings.cache_clear()

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -354,4 +354,6 @@ def test_draft_detail_shows_success_result_with_technical_details_link(client: T
 
     assert "eBay-Draft erfolgreich erstellt" in detail.text
     assert 'href="#technical-details"' in detail.text
+    assert 'href="/drafts"' in detail.text
+    assert "Zurück zur Übersicht" in detail.text
     assert "Technische Details anzeigen" in detail.text


### PR DESCRIPTION
## Summary
- add a server-rendered `/drafts` overview page for existing drafts
- show draft ID, SKU, workflow status and timestamps with direct links back to each draft
- add homepage entry point, modern card-based styling and coverage for empty + populated states

## Testing
- ./.venv/bin/pytest

Fixes #17