### PR TITLE
feat: suggest prioritized optional eBay category aspects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Die Kategorieauswahl ist nicht hart im Code verdrahtet. Open Inserto nutzt eBay 
 
 Die Kategorie-Suche auf der Draft-Seite läuft asynchron. Wird keine passende Kategorie automatisch gewählt, bleibt der Draft bearbeitbar und die eBay-Angaben werden geöffnet, damit Kategorie und fehlende Merkmale direkt sichtbar sind.
 
-Nach Auswahl einer Kategorie lädt Open Inserto die Kategorie-Merkmale über eBay `get_item_aspects_for_category`. Pflichtmerkmale werden vor dem Vorbereiten oder Veröffentlichen geprüft.
+Nach Auswahl einer Kategorie lädt Open Inserto die Kategorie-Merkmale über eBay `get_item_aspects_for_category`. Pflichtmerkmale werden vor dem Vorbereiten oder Veröffentlichen geprüft. Zusätzlich priorisiert die App optionale Merkmale heuristisch und zeigt nur die relevantesten als KI-gestützte Vorschläge im Draft an.
 
 ## KI-Analyse
 
@@ -64,7 +64,7 @@ VISION_IMAGE_DETAIL=low
 VISION_MAX_IMAGES=4
 ```
 
-Damit bleibt die Analyse bewusst token- und kostenarm. Für Pflichtmerkmale nutzt Open Inserto zusätzliche gezielte KI-Abfragen nur dann, wenn die Kategorie bekannt ist und noch eBay-relevante Angaben fehlen.
+Damit bleibt die Analyse bewusst token- und kostenarm. Für Pflichtmerkmale und priorisierte optionale Merkmale nutzt Open Inserto zusätzliche gezielte KI-Abfragen nur dann, wenn die Kategorie bekannt ist und noch eBay-relevante Angaben fehlen. Automatisch gesetzte Merkmale werden intern mit Quelle und Confidence markiert.
 
 ## eBay Modus
 

--- a/app/drafts/analysis.py
+++ b/app/drafts/analysis.py
@@ -15,7 +15,7 @@ from app.drafts.included_items import normalize_included_items
 from app.drafts.models import Draft, ListingData
 from app.drafts.rendering import render_listing_description
 from app.drafts.vision import OpenAIVisionAnalyzerClient
-from app.marketplaces.ebay.taxonomy import get_category_resolution, get_required_category_aspects
+from app.marketplaces.ebay.taxonomy import get_category_resolution, get_optional_category_aspects, get_required_category_aspects
 
 logger = logging.getLogger(__name__)
 
@@ -211,22 +211,24 @@ class VisionDraftAnalysisService:
 
 def autofill_ebay_required_aspects(draft: Draft, settings: Settings) -> bool:
     required_aspects = get_required_category_aspects(draft)
-    if not required_aspects:
+    optional_aspects = [aspect for aspect in get_optional_category_aspects(draft) if str(aspect.get("priority") or "") in {"high", "medium"}][:6]
+    candidate_aspects = [*required_aspects, *optional_aspects]
+    if not candidate_aspects:
         return False
 
     existing = _ebay_aspect_values(draft)
     updated = dict(existing)
     changed = False
-    for aspect in required_aspects:
+    for aspect in candidate_aspects:
         name = _clean_text(aspect.get("name"))
         if not name or updated.get(name):
             continue
-        value = _infer_required_aspect_value(draft, aspect)
+        value = _infer_aspect_value(draft, aspect)
         if value:
             updated[name] = value
             changed = True
 
-    missing = [aspect for aspect in required_aspects if not updated.get(_clean_text(aspect.get("name")))]
+    missing = [aspect for aspect in candidate_aspects if not updated.get(_clean_text(aspect.get("name")))]
     category_id = str(get_category_resolution(draft).get("selected_id") or draft.listing.category_suggestion or "").strip()
     autofill_metadata = draft.listing.attributes.get("ebayAspectsAutofill")
     autofill_metadata = autofill_metadata if isinstance(autofill_metadata, dict) else {}
@@ -251,9 +253,10 @@ def autofill_ebay_required_aspects(draft: Draft, settings: Settings) -> bool:
                 user_input=draft.source.user_input,
                 listing=_listing_context(draft),
                 category=get_category_resolution(draft),
-                required_aspects=missing,
+                candidate_aspects=missing,
                 image_payloads=vision_service._build_image_payloads(draft),
             )
+            aspect_metadata = _ebay_aspect_metadata(draft)
             for item in ai_aspects:
                 name = _clean_text(item.get("name"))
                 if not name or updated.get(name):
@@ -264,11 +267,34 @@ def autofill_ebay_required_aspects(draft: Draft, settings: Settings) -> bool:
                 value = _normalize_aspect_value(item.get("value"), aspect)
                 if value:
                     updated[name] = value
+                    aspect_metadata[name] = {
+                        "source": "ai",
+                        "confidence": _clean_text(item.get("confidence")).lower() or "medium",
+                        "priority": str(aspect.get("priority") or ("high" if aspect.get("required") else "medium")),
+                    }
                     changed = True
+            if aspect_metadata:
+                draft.listing.attributes["ebayAspectsMeta"] = aspect_metadata
         except Exception as exc:
             logger.warning("OpenAI eBay aspect autofill failed for draft %s: %s", draft.id, exc)
 
     if changed:
+        aspect_metadata = _ebay_aspect_metadata(draft)
+        for aspect in candidate_aspects:
+            name = _clean_text(aspect.get("name"))
+            if not name or not updated.get(name):
+                continue
+            aspect_metadata.setdefault(
+                name,
+                {
+                    "source": "deterministic",
+                    "confidence": "high",
+                    "priority": str(aspect.get("priority") or ("high" if aspect.get("required") else "medium")),
+                },
+            )
+        if aspect_metadata:
+            draft.listing.attributes["ebayAspectsMeta"] = aspect_metadata
+
         draft.listing.attributes["ebayAspects"] = updated
         sources = draft.listing.attributes.get("fieldSources")
         if isinstance(sources, dict):
@@ -407,7 +433,20 @@ def _ebay_aspect_values(draft: Draft) -> dict[str, str]:
     return {str(key).strip(): str(value).strip() for key, value in values.items() if str(key).strip() and str(value).strip()}
 
 
-def _infer_required_aspect_value(draft: Draft, aspect: dict[str, Any]) -> str:
+def _ebay_aspect_metadata(draft: Draft) -> dict[str, dict[str, str]]:
+    raw_value = draft.listing.attributes.get("ebayAspectsMeta")
+    if not isinstance(raw_value, dict):
+        return {}
+    metadata: dict[str, dict[str, str]] = {}
+    for key, value in raw_value.items():
+        name = str(key).strip()
+        if not name or not isinstance(value, dict):
+            continue
+        metadata[name] = {str(inner_key).strip(): str(inner_value).strip() for inner_key, inner_value in value.items() if str(inner_key).strip() and str(inner_value).strip()}
+    return metadata
+
+
+def _infer_aspect_value(draft: Draft, aspect: dict[str, Any]) -> str:
     name = _clean_text(aspect.get("name"))
     name_key = name.casefold()
     if name_key in {"marke", "markenkompatibilität", "kompatible marke"}:
@@ -420,6 +459,8 @@ def _infer_required_aspect_value(draft: Draft, aspect: dict[str, Any]) -> str:
             return value
         category = get_category_resolution(draft)
         return _normalize_aspect_value(category.get("selected_name"), aspect)
+    if name_key in {"farbe", "colour", "color"}:
+        return _match_allowed_value(_product_context_text(draft), aspect)
     return _match_allowed_value(_product_context_text(draft), aspect)
 
 

--- a/app/drafts/vision.py
+++ b/app/drafts/vision.py
@@ -149,12 +149,12 @@ class OpenAIVisionAnalyzerClient:
         user_input: dict[str, Any],
         listing: dict[str, Any],
         category: dict[str, Any],
-        required_aspects: list[dict[str, Any]],
+        candidate_aspects: list[dict[str, Any]],
         image_payloads: list[dict[str, str]],
     ) -> list[dict[str, str]]:
         if not self.api_key:
             raise ValueError("Vision API key fehlt")
-        if not required_aspects:
+        if not candidate_aspects:
             return []
 
         response_format = {
@@ -183,7 +183,7 @@ class OpenAIVisionAnalyzerClient:
             },
         }
         prompt = (
-            "Fülle nur die angefragten eBay-Kategoriepflichtmerkmale für den Verkaufsentwurf. "
+            "Fülle nur die angefragten eBay-Kategoriemerkmale für den Verkaufsentwurf. Pflichtmerkmale haben Vorrang, optionale Merkmale nur wenn sie relevant und gut belegbar sind. "
             "Nutze vorhandene Entwurfsdaten, Nutzerangaben und sichtbare Bildinhalte. "
             "Erfinde keine Werte. Wenn ein Wert nicht sicher aus Titel, Marke, Modell, Nutzerangaben oder Bildern ableitbar ist, "
             "gib für dieses Merkmal einen leeren value zurück. "
@@ -192,7 +192,7 @@ class OpenAIVisionAnalyzerClient:
             "Für Modellkompatibilität darf das erkannte Modell verwendet werden, wenn es um Zubehör, Ersatzteile oder Kompatibilität geht. "
             "Für Produktart verwende eine kurze sachliche Produktart, möglichst aus allowedValues oder der eBay-Kategorie. "
             f"notes={notes!r}; user_input={user_input!r}; listing={listing!r}; category={category!r}; "
-            f"required_aspects={required_aspects!r}"
+            f"candidate_aspects={candidate_aspects!r}"
         )
         content: list[dict[str, Any]] = [{"type": "input_text", "text": prompt}]
         for image_payload in image_payloads:
@@ -222,7 +222,7 @@ class OpenAIVisionAnalyzerClient:
                     "OpenAI eBay aspect request failed: status=%s model=%s aspect_count=%s body=%s",
                     response.status_code,
                     self.model,
-                    len(required_aspects),
+                    len(candidate_aspects),
                     _truncate_for_log(response.text),
                 )
             response.raise_for_status()

--- a/app/marketplaces/ebay/client.py
+++ b/app/marketplaces/ebay/client.py
@@ -40,7 +40,7 @@ class EbayOfferAlreadyExistsError(EbayValidationError):
     offer_id: str
 
     def __init__(self, offer_id: str, message: str):
-        super().__init__(message)
+        EbayValidationError.__init__(self, message)
         self.offer_id = offer_id
 
 

--- a/app/marketplaces/ebay/taxonomy.py
+++ b/app/marketplaces/ebay/taxonomy.py
@@ -204,6 +204,77 @@ def get_required_category_aspects(draft: Draft) -> list[dict[str, Any]]:
     ]
 
 
+def get_optional_category_aspects(draft: Draft) -> list[dict[str, Any]]:
+    aspects = _category_metadata(draft).get("aspects")
+    if not isinstance(aspects, list):
+        return []
+
+    ranked: list[dict[str, Any]] = []
+    for item in aspects:
+        if not isinstance(item, dict) or item.get("required"):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        enriched = dict(item)
+        enriched["priority"] = _optional_aspect_priority(draft, enriched)
+        ranked.append(enriched)
+
+    priority_order = {"high": 0, "medium": 1, "low": 2}
+    ranked.sort(key=lambda item: (priority_order.get(str(item.get("priority") or "low"), 3), str(item.get("name") or "").casefold()))
+    return ranked
+
+
+def _optional_aspect_priority(draft: Draft, aspect: dict[str, Any]) -> str:
+    name = str(aspect.get("name") or "").strip().casefold()
+    if not name:
+        return "low"
+
+    context = " ".join(
+        part.casefold()
+        for part in (
+            draft.listing.title,
+            draft.listing.brand,
+            draft.listing.model,
+            str(_category_metadata(draft).get("selected_name") or ""),
+            str(_category_metadata(draft).get("selected_path") or ""),
+            " ".join(_detail_labels(draft)),
+        )
+        if isinstance(part, str) and part.strip()
+    )
+
+    if name in {
+        "marke", "modell", "produktart", "typ", "farbe", "größe", "material", "breite", "höhe", "länge",
+        "tiefe", "speicherkapazität", "konnektivität", "anschlüsse", "kompatibilität", "markenkompatibilität",
+        "modellkompatibilität", "bildschirmgröße", "produktlinie", "formfaktor",
+    }:
+        return "high"
+    if any(token in name for token in {"kompat", "größe", "farbe", "material", "anschluss", "kapaz", "modell", "marke"}):
+        return "high"
+    if any(token in name for token in {"breite", "höhe", "länge", "tiefe", "gewicht", "format", "leistung", "spannung", "energie", "durchmesser"}):
+        return "medium"
+    if context and any(token in context for token in {"lautsprecher", "audio", "tv", "monitor", "konsole", "kleidung", "möbel"}):
+        if any(token in name for token in {"farbe", "größe", "material", "konnektivität", "anschlüsse", "modell", "marke"}):
+            return "high"
+        if any(token in name for token in {"breite", "höhe", "länge", "tiefe", "gewicht"}):
+            return "medium"
+    return "low"
+
+
+def _detail_labels(draft: Draft) -> list[str]:
+    raw_details = draft.listing.attributes.get("keyTechnicalDetails")
+    if not isinstance(raw_details, list):
+        return []
+    labels: list[str] = []
+    for item in raw_details:
+        if not isinstance(item, str):
+            continue
+        label = item.split(":", 1)[0].strip()
+        if label:
+            labels.append(label)
+    return labels
+
+
 def _category_metadata(draft: Draft) -> dict[str, Any]:
     metadata = draft.listing.attributes.get("ebayCategory")
     return metadata if isinstance(metadata, dict) else {}

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -497,6 +497,129 @@ code {
   margin-top: 0.5rem;
 }
 
+.searchable-select {
+  position: relative;
+}
+
+.searchable-select:not(.searchable-select--enhanced) .searchable-select__button,
+.searchable-select:not(.searchable-select--enhanced) .searchable-select__panel {
+  display: none;
+}
+
+.searchable-select--enhanced .js-searchable-select {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.searchable-select__button {
+  display: flex;
+  width: 100%;
+  min-height: 3.25rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid rgba(117, 132, 168, 0.28);
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  background: white;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.searchable-select__button::after {
+  content: "";
+  width: 0.52rem;
+  height: 0.52rem;
+  flex: 0 0 auto;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg) translateY(-0.12rem);
+  opacity: 0.58;
+}
+
+.searchable-select__button:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.16);
+  outline-offset: 1px;
+  border-color: rgba(37, 99, 235, 0.55);
+}
+
+.searchable-select__button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.searchable-select__panel {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  display: grid;
+  gap: 0.45rem;
+  max-height: 18rem;
+  padding: 0.55rem;
+  border: 1px solid rgba(117, 132, 168, 0.22);
+  border-radius: 16px;
+  background: white;
+  box-shadow: 0 18px 44px rgba(47, 55, 40, 0.15);
+}
+
+.searchable-select__panel[hidden] {
+  display: none;
+}
+
+.field .searchable-select__search {
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+
+.searchable-select__options {
+  display: grid;
+  gap: 0.2rem;
+  max-height: 12.5rem;
+  overflow-y: auto;
+  padding-right: 0.15rem;
+}
+
+.searchable-select__option {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-radius: 10px;
+  padding: 0.62rem 0.7rem;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.searchable-select__option:hover,
+.searchable-select__option:focus,
+.searchable-select__option[aria-selected="true"] {
+  outline: 0;
+  background: var(--surface-muted);
+}
+
+.searchable-select__option[aria-selected="true"] {
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.searchable-select__empty {
+  margin: 0;
+  padding: 0.65rem 0.7rem;
+  color: var(--text-soft);
+  font-size: 0.88rem;
+}
+
 .suggestion-list__item strong,
 .suggestion-list__item span,
 .suggestion-list__item p {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -5,6 +5,38 @@
   <span class="field-source field-source--{{ 'ai' if source == 'KI' else 'edited' if source == 'Bearbeitet' else 'user' }}">{{ source }}</span>
 {%- endmacro %}
 
+{% macro aspect_value_select(control_id, aspect_name, aspect_options, current_value, empty_label) -%}
+  <div class="searchable-select" data-searchable-select>
+    <select id="{{ control_id }}" name="ebay_aspect__{{ aspect_name }}" class="js-searchable-select">
+      <option value="">{{ empty_label }}</option>
+      {% for value in aspect_options %}
+        <option value="{{ value }}" {% if current_value == value %}selected{% endif %}>{{ value }}</option>
+      {% endfor %}
+    </select>
+    <button
+      class="searchable-select__button"
+      type="button"
+      aria-haspopup="listbox"
+      aria-expanded="false"
+      data-searchable-select-button
+    >
+      <span data-searchable-select-label>{{ current_value or empty_label }}</span>
+    </button>
+    <div class="searchable-select__panel" data-searchable-select-panel hidden>
+      <input
+        class="searchable-select__search"
+        type="search"
+        autocomplete="off"
+        placeholder="Wert suchen"
+        aria-label="{{ aspect_name }} suchen"
+        data-searchable-select-search
+      >
+      <div class="searchable-select__options" role="listbox" data-searchable-select-options></div>
+      <p class="searchable-select__empty" data-searchable-select-empty hidden>Kein passender Wert</p>
+    </div>
+  </div>
+{%- endmacro %}
+
 {% block title %}{{ app_name }} - Draft {{ draft.id }}{% endblock %}
 
 {% block content %}
@@ -271,12 +303,7 @@
               <label class="field" for="ebay_aspect_{{ loop.index }}">
                 <span>{{ aspect_name }}</span>
                 {% if aspect_options %}
-                  <select id="ebay_aspect_{{ loop.index }}" name="ebay_aspect__{{ aspect_name }}">
-                    <option value="">Bitte auswählen</option>
-                    {% for value in aspect_options %}
-                      <option value="{{ value }}" {% if ebay_aspect_values.get(aspect_name) == value %}selected{% endif %}>{{ value }}</option>
-                    {% endfor %}
-                  </select>
+                  {{ aspect_value_select('ebay_aspect_' ~ loop.index, aspect_name, aspect_options, ebay_aspect_values.get(aspect_name), 'Bitte auswählen') }}
                 {% else %}
                   <input id="ebay_aspect_{{ loop.index }}" name="ebay_aspect__{{ aspect_name }}" type="text" value="{{ ebay_aspect_values.get(aspect_name, '') }}" placeholder="{{ aspect_name }}">
                 {% endif %}
@@ -303,12 +330,7 @@
                   </small>
                 </span>
                 {% if aspect_options %}
-                  <select id="ebay_optional_aspect_{{ loop.index }}" name="ebay_aspect__{{ aspect_name }}">
-                    <option value="">Optional auswählen</option>
-                    {% for value in aspect_options %}
-                      <option value="{{ value }}" {% if ebay_aspect_values.get(aspect_name) == value %}selected{% endif %}>{{ value }}</option>
-                    {% endfor %}
-                  </select>
+                  {{ aspect_value_select('ebay_optional_aspect_' ~ loop.index, aspect_name, aspect_options, ebay_aspect_values.get(aspect_name), 'Optional auswählen') }}
                 {% else %}
                   <input id="ebay_optional_aspect_{{ loop.index }}" name="ebay_aspect__{{ aspect_name }}" type="text" value="{{ ebay_aspect_values.get(aspect_name, '') }}" placeholder="{{ aspect_name }}">
                 {% endif %}
@@ -469,6 +491,114 @@
   const categorySearchResults = document.querySelector("#category_search_results");
   const categorySuggestionInput = document.querySelector("#category_suggestion");
 
+  function initializeSearchableSelects(root = document) {
+    root.querySelectorAll("[data-searchable-select]").forEach((container) => {
+      if (container.dataset.enhanced === "true") {
+        return;
+      }
+      const select = container.querySelector(".js-searchable-select");
+      const button = container.querySelector("[data-searchable-select-button]");
+      const label = container.querySelector("[data-searchable-select-label]");
+      const panel = container.querySelector("[data-searchable-select-panel]");
+      const search = container.querySelector("[data-searchable-select-search]");
+      const optionsList = container.querySelector("[data-searchable-select-options]");
+      const emptyState = container.querySelector("[data-searchable-select-empty]");
+      if (!select || !button || !label || !panel || !search || !optionsList || !emptyState) {
+        return;
+      }
+
+      container.dataset.enhanced = "true";
+      container.classList.add("searchable-select--enhanced");
+
+      const options = Array.from(select.options).map((option) => ({
+        value: option.value,
+        label: option.textContent.trim(),
+      }));
+
+      function currentOption() {
+        return options.find((option) => option.value === select.value) || options[0];
+      }
+
+      function updateLabel() {
+        const option = currentOption();
+        label.textContent = option ? option.label : "";
+      }
+
+      function closePanel() {
+        panel.hidden = true;
+        button.setAttribute("aria-expanded", "false");
+      }
+
+      function openPanel() {
+        panel.hidden = false;
+        button.setAttribute("aria-expanded", "true");
+        search.value = "";
+        renderOptions("");
+        window.requestAnimationFrame(() => search.focus());
+      }
+
+      function selectValue(value) {
+        select.value = value;
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+        updateLabel();
+        closePanel();
+        button.focus();
+      }
+
+      function renderOptions(query) {
+        const normalizedQuery = query.trim().toLocaleLowerCase();
+        optionsList.innerHTML = "";
+        let visibleCount = 0;
+        options.forEach((option) => {
+          if (normalizedQuery && !option.label.toLocaleLowerCase().includes(normalizedQuery)) {
+            return;
+          }
+          visibleCount += 1;
+          const optionButton = document.createElement("button");
+          optionButton.type = "button";
+          optionButton.className = "searchable-select__option";
+          optionButton.dataset.value = option.value;
+          optionButton.setAttribute("role", "option");
+          optionButton.setAttribute("aria-selected", option.value === select.value ? "true" : "false");
+          optionButton.textContent = option.label;
+          optionButton.addEventListener("click", () => selectValue(option.value));
+          optionsList.append(optionButton);
+        });
+        emptyState.hidden = visibleCount > 0;
+      }
+
+      button.addEventListener("click", () => {
+        if (panel.hidden) {
+          openPanel();
+        } else {
+          closePanel();
+        }
+      });
+      search.addEventListener("input", () => renderOptions(search.value));
+      search.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          closePanel();
+          button.focus();
+          return;
+        }
+        if (event.key === "Enter") {
+          const firstOption = optionsList.querySelector(".searchable-select__option");
+          if (firstOption) {
+            event.preventDefault();
+            selectValue(firstOption.dataset.value || "");
+          }
+        }
+      });
+      select.addEventListener("change", updateLabel);
+      document.addEventListener("click", (event) => {
+        if (!container.contains(event.target)) {
+          closePanel();
+        }
+      });
+      updateLabel();
+    });
+  }
+
   function escapeHtml(value) {
     return String(value || "")
       .replace(/&/g, "&amp;")
@@ -539,5 +669,7 @@
       }
     });
   }
+
+  initializeSearchableSelects();
 </script>
 {% endblock %}

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -286,6 +286,38 @@
           <p class="field-help">Diese Merkmale kommen direkt aus der gewählten eBay-Kategorie und werden beim Veröffentlichen übertragen.</p>
         </div>
       {% endif %}
+      {% if optional_category_aspects %}
+        <div class="field field--full">
+          <span>Empfohlene optionale eBay-Merkmale</span>
+          <div class="category-aspect-list">
+            {% for aspect in optional_category_aspects if aspect.get('priority') in ['high', 'medium'] %}
+              {% set aspect_name = aspect.get('name') %}
+              {% set aspect_options = aspect.get('values', []) %}
+              {% set aspect_meta = ebay_aspect_metadata.get(aspect_name, {}) %}
+              <label class="field" for="ebay_optional_aspect_{{ loop.index }}">
+                <span>
+                  {{ aspect_name }}
+                  <small>
+                    {{ 'hoch priorisiert' if aspect.get('priority') == 'high' else 'sinnvoll bei guten Daten' }}
+                    {% if aspect_meta.get('source') == 'ai' %} · KI-Vorschlag{% elif aspect_meta.get('source') == 'deterministic' %} · automatisch erkannt{% endif %}
+                  </small>
+                </span>
+                {% if aspect_options %}
+                  <select id="ebay_optional_aspect_{{ loop.index }}" name="ebay_aspect__{{ aspect_name }}">
+                    <option value="">Optional auswählen</option>
+                    {% for value in aspect_options %}
+                      <option value="{{ value }}" {% if ebay_aspect_values.get(aspect_name) == value %}selected{% endif %}>{{ value }}</option>
+                    {% endfor %}
+                  </select>
+                {% else %}
+                  <input id="ebay_optional_aspect_{{ loop.index }}" name="ebay_aspect__{{ aspect_name }}" type="text" value="{{ ebay_aspect_values.get(aspect_name, '') }}" placeholder="{{ aspect_name }}">
+                {% endif %}
+              </label>
+            {% endfor %}
+          </div>
+          <p class="field-help">Open Inserto schlägt nur priorisierte optionale Merkmale vor. Unsichere Felder bleiben leer.</p>
+        </div>
+      {% endif %}
     </details>
 
     <div class="button-row">

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -29,7 +29,7 @@ from app.marketplaces.ebay.service import EbayMarketplaceService
 from app.marketplaces.ebay.auth import EbayAuthStore, build_auth_connect_url, has_usable_auth_tokens
 from app.marketplaces.ebay.client import EbayApiError, EbayAuthError, EbayClient, EbayValidationError, normalize_search_text
 from app.marketplaces.ebay.configuration import DEFAULT_SHIPPING_PROFILE, PAYMENT_POLICY_NAME, RETURN_POLICY_NAME, SHIPPING_PROFILES, EbayConfigStore, normalize_shipping_profile
-from app.marketplaces.ebay.taxonomy import get_category_resolution, get_required_category_aspects, resolve_category_search_for_draft, resolve_category_suggestion_for_draft
+from app.marketplaces.ebay.taxonomy import get_category_resolution, get_optional_category_aspects, get_required_category_aspects, resolve_category_search_for_draft, resolve_category_suggestion_for_draft
 from app.marketplaces.ebay.validation import collect_marketplace_notes, collect_marketplace_readiness_errors
 
 router = APIRouter()
@@ -161,6 +161,19 @@ def get_ebay_aspect_values(draft) -> dict[str, str]:
     if not isinstance(values, dict):
         return {}
     return {str(key): str(value) for key, value in values.items()}
+
+
+def get_ebay_aspect_metadata(draft) -> dict[str, dict[str, str]]:
+    values = draft.listing.attributes.get("ebayAspectsMeta")
+    if not isinstance(values, dict):
+        return {}
+    metadata: dict[str, dict[str, str]] = {}
+    for key, value in values.items():
+        name = str(key).strip()
+        if not name or not isinstance(value, dict):
+            continue
+        metadata[name] = {str(inner_key): str(inner_value) for inner_key, inner_value in value.items()}
+    return metadata
 
 
 def update_ebay_aspects_from_form(draft, form: Any) -> None:
@@ -523,6 +536,7 @@ def draft_detail(request: Request, draft_id: str):
     )
     category_resolution = get_category_resolution(draft)
     required_category_aspects = get_required_category_aspects(draft)
+    optional_category_aspects = get_optional_category_aspects(draft)
 
     return templates.TemplateResponse(
         request,
@@ -538,7 +552,9 @@ def draft_detail(request: Request, draft_id: str):
             analysis_state=get_analysis_state(draft),
             category_resolution=category_resolution,
             required_category_aspects=required_category_aspects,
+            optional_category_aspects=optional_category_aspects,
             ebay_aspect_values=get_ebay_aspect_values(draft),
+            ebay_aspect_metadata=get_ebay_aspect_metadata(draft),
             open_ebay_details=should_open_ebay_details(category_resolution, required_category_aspects, marketplace_readiness_errors),
             review_form_values=get_review_form_values(draft),
             review_metadata=get_review_metadata(draft),

--- a/docs/adr/0016-ebay-inventory-offer-category-flow.md
+++ b/docs/adr/0016-ebay-inventory-offer-category-flow.md
@@ -57,6 +57,8 @@ Die manuelle Kategorie-Suche auf der Draft-Seite läuft asynchron. Die Seite sol
 
 Nach Auswahl oder Auflösung einer Kategorie lädt Open Inserto die kategoriespezifischen Artikelmerkmale über `get_item_aspects_for_category`.
 
+Pflichtmerkmale werden weiterhin strikt validiert. Optionale Merkmale werden zusätzlich heuristisch priorisiert, damit nur fachlich relevante Kandidaten automatisch vorgeschlagen oder per Vision-Modell nachermittelt werden. Die Speicherung von `ebayAspects` bleibt breit genug, damit sowohl Pflicht- als auch priorisierte optionale Felder ohne weiteres Spezialmapping in den eBay-Inventory-Payload laufen.
+
 Pflichtmerkmale werden vor dem eBay-Schritt geprüft. Fehlende Pflichtmerkmale blockieren das Vorbereiten oder Veröffentlichen, bis sie vorhanden sind.
 
 Open Inserto versucht Pflichtmerkmale automatisch zu füllen:

--- a/tests/test_draft_analysis.py
+++ b/tests/test_draft_analysis.py
@@ -18,6 +18,7 @@ from app.drafts.analysis import (
 from app.core.config import Settings
 from app.drafts.models import Draft, SourceImage, WorkflowStatus
 from app.drafts.vision import _extract_structured_output
+from app.marketplaces.ebay.taxonomy import get_optional_category_aspects
 
 
 class StubVisionClient:
@@ -451,3 +452,78 @@ def test_autofill_ebay_required_aspects_uses_existing_listing_data(tmp_path: Pat
         "Modellkompatibilität": "SoundTouch 10",
         "Produktart": "Lautsprecher",
     }
+
+
+def test_get_optional_category_aspects_prioritizes_relevant_fields():
+    draft = Draft(
+        id="draft_optional_priority",
+        sku="OIN-OPTIONAL",
+        listing={
+            "title": "Bose SoundTouch 10 Lautsprecher schwarz",
+            "brand": "Bose",
+            "model": "SoundTouch 10",
+            "attributes": {
+                "keyTechnicalDetails": ["Konnektivität: WLAN, Bluetooth"],
+                "ebayCategory": {
+                    "selected_name": "Lautsprecher & Subwoofer",
+                    "selected_path": "TV, Video & Audio > Heim-Audio & HiFi > Lautsprecher & Subwoofer",
+                    "aspects": [
+                        {"name": "Farbe", "required": False, "values": ["Schwarz", "Weiß"]},
+                        {"name": "Konnektivität", "required": False, "values": ["Bluetooth", "WLAN"]},
+                        {"name": "Gewicht", "required": False, "values": []},
+                    ],
+                }
+            },
+        },
+    )
+
+    aspects = get_optional_category_aspects(draft)
+
+    assert [aspect["name"] for aspect in aspects] == ["Farbe", "Konnektivität", "Gewicht"]
+    assert aspects[0]["priority"] == "high"
+    assert aspects[1]["priority"] == "high"
+    assert aspects[2]["priority"] == "medium"
+
+
+def test_autofill_ebay_required_aspects_adds_prioritized_optional_fields(tmp_path: Path):
+    settings = Settings(
+        project_dir=tmp_path,
+        data_dir=tmp_path / "data",
+        database_url=f"sqlite:///{tmp_path / 'open_inserto.db'}",
+        draft_analysis_backend="heuristic",
+        _env_file=None,
+    )
+    draft = Draft(
+        id="draft_optional_fill",
+        sku="OIN-OPTIONAL-FILL",
+        listing={
+            "title": "Bose SoundTouch 10 Lautsprecher schwarz mit Bluetooth",
+            "brand": "Bose",
+            "model": "SoundTouch 10",
+            "categorySuggestion": "14990",
+            "attributes": {
+                "ebayCategory": {
+                    "state": "manual_id",
+                    "selected_id": "14990",
+                    "selected_name": "Lautsprecher & Subwoofer",
+                    "selected_path": "TV, Video & Audio > Heim-Audio & HiFi > Lautsprecher & Subwoofer",
+                    "aspects": [
+                        {"name": "Marke", "required": True, "values": []},
+                        {"name": "Farbe", "required": False, "values": ["Schwarz", "Weiß"]},
+                        {"name": "Konnektivität", "required": False, "values": ["Bluetooth", "WLAN"]},
+                    ],
+                }
+            },
+        },
+    )
+
+    changed = autofill_ebay_required_aspects(draft, settings)
+
+    assert changed is True
+    assert draft.listing.attributes["ebayAspects"] == {
+        "Marke": "Bose",
+        "Farbe": "Schwarz",
+        "Konnektivität": "Bluetooth",
+    }
+    assert draft.listing.attributes["ebayAspectsMeta"]["Farbe"]["source"] == "deterministic"
+    assert draft.listing.attributes["ebayAspectsMeta"]["Konnektivität"]["priority"] == "high"


### PR DESCRIPTION
## Summary
- expand eBay aspect autofill from required-only to required plus prioritized optional category aspects
- surface recommended optional aspects in the draft UI and store source/confidence metadata
- document the behavior and fix the existing offer-already-exists exception regression found while validating the baseline

## Testing
- source .venv/bin/activate && pytest tests/test_draft_analysis.py tests/test_ebay_taxonomy.py tests/test_upload_flow.py tests/test_ebay_marketplace.py tests/test_draft_review.py

Closes #25 