### PR TITLE
feat: add conversational assisted-selling beta flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ http://localhost:8000/integrations/ebay/callback?code=<CODE>&state=<STATE>
 
 Das aktuelle MVP bleibt bewusst serverseitig und formularnah, ist aber nicht das endgültige Zielbild.
 
-Die nächste Phase ist ein **chat-artiger Assisted-Selling-Flow**. Ein erster konkreter Beta-Schritt ist bereits im Draft-Detail sichtbar:
+Die nächste Phase ist ein **chat-artiger Assisted-Selling-Flow**. Der aktuelle Stand bringt dafür bereits eine konkrete UI-Referenz mit:
 
-- Einstieg weiter über Bilder
-- sichtbare Analysephase im Verlauf
+- Einstieg über eine Tailwind-basierte, chat-artige Upload-Oberfläche
+- sichtbare AI-Loading-Animation während der Analyse
 - erkannte Kernangaben direkt im Assistenten-Flow bestätigen oder korrigieren
 - fehlende Kerninfos werden schrittweise ohne Full-Page-Reload nachgefragt
 - das klassische Review-Formular bleibt als Fallback und Feinjustierung bestehen

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ http://localhost:8000/integrations/ebay/callback?code=<CODE>&state=<STATE>
 
 Das aktuelle MVP bleibt bewusst serverseitig und formularnah, ist aber nicht das endgültige Zielbild.
 
-Die nächste Phase ist ein **chat-artiger Assisted-Selling-Flow**:
+Die nächste Phase ist ein **chat-artiger Assisted-Selling-Flow**. Ein erster konkreter Beta-Schritt ist bereits im Draft-Detail sichtbar:
 
 - Einstieg weiter über Bilder
 - sichtbare Analysephase im Verlauf
-- erkannte Angaben bestätigen oder korrigieren
-- nur noch gezielte Rückfragen bei Unsicherheit
-- dynamische Nachlade-Logik ohne Full-Page-Reload
+- erkannte Kernangaben direkt im Assistenten-Flow bestätigen oder korrigieren
+- fehlende Kerninfos werden schrittweise ohne Full-Page-Reload nachgefragt
+- das klassische Review-Formular bleibt als Fallback und Feinjustierung bestehen
 
 Die Architekturentscheidung dazu ist in [`docs/adr/0018-conversational-assisted-selling-ui.md`](docs/adr/0018-conversational-assisted-selling-ui.md) festgehalten.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ http://localhost:8000/integrations/ebay/callback?code=<CODE>&state=<STATE>
 
 `state` muss aus demselben Login-Vorgang stammen, weil Open Inserto diesen Wert lokal prüft. Der Login muss deshalb immer zuerst über den Button in Open Inserto gestartet werden.
 
+## Nächste UX-Ausbaustufe
+
+Das aktuelle MVP bleibt bewusst serverseitig und formularnah, ist aber nicht das endgültige Zielbild.
+
+Die nächste Phase ist ein **chat-artiger Assisted-Selling-Flow**:
+
+- Einstieg weiter über Bilder
+- sichtbare Analysephase im Verlauf
+- erkannte Angaben bestätigen oder korrigieren
+- nur noch gezielte Rückfragen bei Unsicherheit
+- dynamische Nachlade-Logik ohne Full-Page-Reload
+
+Die Architekturentscheidung dazu ist in [`docs/adr/0018-conversational-assisted-selling-ui.md`](docs/adr/0018-conversational-assisted-selling-ui.md) festgehalten.
+
 ## Tests
 
 ```bash

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -288,6 +288,66 @@ body {
   align-items: start;
 }
 
+.assistant-preview {
+  margin-top: 1.25rem;
+}
+
+.assistant-preview__chat {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1rem;
+}
+
+.assistant-bubble {
+  max-width: 38rem;
+  padding: 1rem 1.1rem;
+  border-radius: 22px;
+  border: 1px solid var(--border);
+  box-shadow: 0 14px 30px rgba(47, 55, 40, 0.06);
+}
+
+.assistant-bubble strong {
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.assistant-bubble p {
+  margin: 0;
+}
+
+.assistant-bubble--assistant {
+  background: linear-gradient(180deg, rgba(23, 92, 211, 0.08), rgba(255, 255, 255, 0.98));
+}
+
+.assistant-bubble--user {
+  margin-left: auto;
+  background: linear-gradient(180deg, rgba(31, 111, 95, 0.14), rgba(255, 255, 255, 0.98));
+}
+
+.assistant-choice-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+}
+
+.assistant-choice {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(31, 111, 95, 0.12);
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.assistant-choice--secondary {
+  background: rgba(23, 92, 211, 0.08);
+  color: var(--info);
+}
+
 .upload-dropzone {
   min-height: 100%;
   border: 1.5px dashed rgba(37, 99, 235, 0.25);

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -348,6 +348,29 @@ body {
   color: var(--info);
 }
 
+.assistant-workflow {
+  margin-bottom: 1rem;
+}
+
+.assistant-thread {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.assistant-bubble--confirmed {
+  border-color: rgba(2, 122, 72, 0.18);
+  background: linear-gradient(180deg, rgba(2, 122, 72, 0.08), rgba(255, 255, 255, 0.98));
+}
+
+.assistant-choice {
+  border: 0;
+  cursor: pointer;
+}
+
+.assistant-composer {
+  margin-top: 1rem;
+}
+
 .upload-dropzone {
   min-height: 100%;
   border: 1.5px dashed rgba(37, 99, 235, 0.25);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,6 +11,31 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', path='/favicon/favicon-16x16.png') }}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', path='/favicon/apple-touch-icon.png') }}">
     <link rel="manifest" href="{{ url_for('static', path='/favicon/site.webmanifest') }}">
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              brand: {
+                50: '#ecfdf5',
+                100: '#d1fae5',
+                500: '#16a34a',
+                600: '#15803d',
+                700: '#166534',
+                950: '#052e16'
+              }
+            },
+            boxShadow: {
+              soft: '0 20px 45px rgba(15, 23, 42, 0.08)'
+            },
+            animation: {
+              'pulse-soft': 'pulse 2.2s ease-in-out infinite'
+            }
+          }
+        }
+      }
+    </script>
     <link rel="stylesheet" href="{{ url_for('static', path='/css/app.css') }}">
   </head>
   <body>

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -105,15 +105,26 @@
   </section>
 {% endif %}
 
-<section class="card assistant-workflow" id="assistant-flow" data-assistant-flow data-draft-id="{{ draft.id }}">
+<section class="card assistant-workflow border border-emerald-100 bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 text-white shadow-soft" id="assistant-flow" data-assistant-flow data-draft-id="{{ draft.id }}">
   <div class="section-head section-head--compact">
     <div>
-      <p class="eyebrow">Assistenten-Flow</p>
-      <h2>Chat-artige Rückfragen ohne Reload</h2>
+      <p class="eyebrow text-emerald-200">Assistenten-Flow</p>
+      <h2 class="text-white">Chat-artige Rückfragen ohne Reload</h2>
     </div>
-    <span class="status-chip status-chip--muted">Beta</span>
+    <span class="status-chip status-chip--muted border-white/10 bg-white/10 text-white">Beta</span>
   </div>
-  <p class="section-copy">Der Assistent bestätigt erkannte Angaben direkt im Verlauf und fragt fehlende Kerninfos schrittweise nach.</p>
+  <p class="section-copy text-slate-200">Der Assistent bestätigt erkannte Angaben direkt im Verlauf, zeigt eine sichtbare Analysephase und fragt fehlende Kerninfos schrittweise nach.</p>
+  <div class="mb-5 flex items-center gap-4 rounded-3xl border border-white/10 bg-white/5 px-4 py-4">
+    <div class="relative h-12 w-12 shrink-0">
+      <span class="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping"></span>
+      <span class="absolute inset-1 rounded-full bg-emerald-400/30 animate-pulse"></span>
+      <span class="absolute inset-[10px] rounded-full bg-emerald-400"></span>
+    </div>
+    <div>
+      <p class="text-sm font-semibold text-white">AI-Analyse aktiv</p>
+      <p class="text-sm text-slate-300">Erkannte Angaben werden im Gespräch bestätigt oder direkt korrigiert.</p>
+    </div>
+  </div>
   <div class="assistant-thread" data-assistant-thread>
     {% for message in assistant_flow.messages %}
       <article class="assistant-bubble assistant-bubble--{{ 'user' if message.role == 'user' else 'assistant' }}{% if message.tone == 'confirmed' %} assistant-bubble--confirmed{% endif %}">
@@ -129,10 +140,10 @@
       </article>
     {% endfor %}
   </div>
-  <form class="assistant-composer" data-assistant-composer hidden>
+  <form class="assistant-composer rounded-3xl border border-white/10 bg-white/5 p-4" data-assistant-composer hidden>
     <label class="field field--full">
-      <span data-assistant-prompt>Antwort</span>
-      <textarea name="value" rows="3" placeholder="Antwort hier eingeben"></textarea>
+      <span class="text-slate-100" data-assistant-prompt>Antwort</span>
+      <textarea class="rounded-2xl border-white/10 bg-slate-950 text-white placeholder:text-slate-400" name="value" rows="3" placeholder="Antwort hier eingeben"></textarea>
     </label>
     <div class="button-row button-row--single">
       <button class="button button--primary" type="submit">Antwort senden</button>

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -105,6 +105,41 @@
   </section>
 {% endif %}
 
+<section class="card assistant-workflow" id="assistant-flow" data-assistant-flow data-draft-id="{{ draft.id }}">
+  <div class="section-head section-head--compact">
+    <div>
+      <p class="eyebrow">Assistenten-Flow</p>
+      <h2>Chat-artige Rückfragen ohne Reload</h2>
+    </div>
+    <span class="status-chip status-chip--muted">Beta</span>
+  </div>
+  <p class="section-copy">Der Assistent bestätigt erkannte Angaben direkt im Verlauf und fragt fehlende Kerninfos schrittweise nach.</p>
+  <div class="assistant-thread" data-assistant-thread>
+    {% for message in assistant_flow.messages %}
+      <article class="assistant-bubble assistant-bubble--{{ 'user' if message.role == 'user' else 'assistant' }}{% if message.tone == 'confirmed' %} assistant-bubble--confirmed{% endif %}">
+        <strong>{{ 'Du' if message.role == 'user' else 'Open Inserto' }}</strong>
+        <p>{{ message.text }}</p>
+        {% if message.actions %}
+          <div class="assistant-choice-row">
+            {% for action in message.actions %}
+              <button class="assistant-choice {% if action.kind == 'edit' %}assistant-choice--secondary{% endif %}" type="button" data-assistant-action="{{ action.kind }}" data-assistant-field="{{ action.field }}">{{ action.label }}</button>
+            {% endfor %}
+          </div>
+        {% endif %}
+      </article>
+    {% endfor %}
+  </div>
+  <form class="assistant-composer" data-assistant-composer hidden>
+    <label class="field field--full">
+      <span data-assistant-prompt>Antwort</span>
+      <textarea name="value" rows="3" placeholder="Antwort hier eingeben"></textarea>
+    </label>
+    <div class="button-row button-row--single">
+      <button class="button button--primary" type="submit">Antwort senden</button>
+    </div>
+  </form>
+</section>
+
 <section class="listing-workbench">
   <aside class="workbench-side">
     <article class="card">
@@ -476,6 +511,90 @@
   </details>
 </section>
 <script>
+  const assistantRoot = document.querySelector('[data-assistant-flow]');
+  const assistantThread = assistantRoot?.querySelector('[data-assistant-thread]');
+  const assistantComposer = assistantRoot?.querySelector('[data-assistant-composer]');
+  const assistantPrompt = assistantRoot?.querySelector('[data-assistant-prompt]');
+  const assistantInput = assistantComposer?.querySelector('textarea[name="value"]');
+  let assistantPendingField = '{{ assistant_flow.pendingField }}';
+
+  const assistantFieldLabel = (field) => {
+    if (field === 'description_html') return 'Beschreibung';
+    if (field === 'included_items') return 'Lieferumfang';
+    if (field === 'condition') return 'Zustand';
+    return 'Produktname';
+  };
+
+  const renderAssistantMessages = (messages) => {
+    if (!assistantThread) return;
+    assistantThread.innerHTML = '';
+    messages.forEach((message) => {
+      const article = document.createElement('article');
+      article.className = `assistant-bubble assistant-bubble--${message.role === 'user' ? 'user' : 'assistant'}${message.tone === 'confirmed' ? ' assistant-bubble--confirmed' : ''}`;
+      const strong = document.createElement('strong');
+      strong.textContent = message.role === 'user' ? 'Du' : 'Open Inserto';
+      article.appendChild(strong);
+      const text = document.createElement('p');
+      text.textContent = message.text;
+      article.appendChild(text);
+      if (Array.isArray(message.actions) && message.actions.length) {
+        const row = document.createElement('div');
+        row.className = 'assistant-choice-row';
+        message.actions.forEach((action) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = `assistant-choice${action.kind === 'edit' ? ' assistant-choice--secondary' : ''}`;
+          button.dataset.assistantAction = action.kind;
+          button.dataset.assistantField = action.field;
+          button.textContent = action.label;
+          row.appendChild(button);
+        });
+        article.appendChild(row);
+      }
+      assistantThread.appendChild(article);
+    });
+  };
+
+  const sendAssistantAction = async (payload) => {
+    if (!assistantRoot) return;
+    const response = await fetch(`/drafts/${assistantRoot.dataset.draftId}/assistant/message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) return;
+    const data = await response.json();
+    assistantPendingField = data.pendingField || '';
+    renderAssistantMessages(data.messages || []);
+    if (!assistantPendingField) {
+      assistantComposer?.setAttribute('hidden', 'hidden');
+    }
+  };
+
+  assistantRoot?.addEventListener('click', async (event) => {
+    const button = event.target.closest('[data-assistant-action]');
+    if (!button) return;
+    const action = button.dataset.assistantAction;
+    const field = button.dataset.assistantField;
+    if (action === 'edit') {
+      assistantPendingField = field;
+      assistantComposer?.removeAttribute('hidden');
+      if (assistantPrompt) assistantPrompt.textContent = `${assistantFieldLabel(field)} eingeben`;
+      assistantInput?.focus();
+      return;
+    }
+    await sendAssistantAction({ action, field });
+  });
+
+  assistantComposer?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!assistantPendingField || !assistantInput?.value.trim()) return;
+    const value = assistantInput.value.trim();
+    assistantInput.value = '';
+    assistantComposer.setAttribute('hidden', 'hidden');
+    await sendAssistantAction({ action: 'answer', field: assistantPendingField, value });
+  });
+
   const shippingProfileSelect = document.querySelector("#shipping_profile");
   const shippingProfileDescription = document.querySelector("#shipping_profile_description");
   if (shippingProfileSelect && shippingProfileDescription) {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -536,6 +536,7 @@
   const assistantInput = assistantComposer?.querySelector('textarea[name="value"]');
   const draftId = '{{ draft.id }}';
   let assistantPendingField = '{{ assistant_flow.pendingField }}';
+  let assistantFieldValues = {{ assistant_flow.fieldValues | tojson }};
 
   function scrollThreadToBottom(behavior = 'smooth') {
     assistantThread?.lastElementChild?.scrollIntoView({ behavior, block: 'end' });
@@ -576,12 +577,12 @@
   };
 
   const assistantFieldCurrentValue = (field) => {
-    if (field === 'title') return document.querySelector('#title')?.value || '';
-    if (field === 'condition') return document.querySelector('#condition')?.value || '';
-    if (field === 'included_items') return document.querySelector('#included_items')?.value || '';
-    if (field === 'description_html') return document.querySelector('#description')?.value || '';
+    if (field === 'title') return assistantFieldValues.title || document.querySelector('#title')?.value || '';
+    if (field === 'condition') return assistantFieldValues.condition || document.querySelector('#condition')?.value || '';
+    if (field === 'included_items') return assistantFieldValues.included_items || document.querySelector('#included_items')?.value || '';
+    if (field === 'description_html') return assistantFieldValues.description_html || document.querySelector('#description')?.value || '';
     if (field === 'category_suggestion') {
-      return document.querySelector('#category_search_query')?.value || document.querySelector('#category_suggestion')?.value || '';
+      return assistantFieldValues.category_suggestion || assistantFieldValues.category_suggestion_id || document.querySelector('#category_search_query')?.value || document.querySelector('#category_suggestion')?.value || '';
     }
     if (field?.startsWith('ebay_aspect::')) {
       const aspectName = field.replace('ebay_aspect::', '');
@@ -590,6 +591,34 @@
     }
     return '';
   };
+
+  function syncAssistantFieldValues(fieldValues) {
+    assistantFieldValues = fieldValues || assistantFieldValues;
+    if (assistantFieldValues.title !== undefined) {
+      const input = document.querySelector('#title');
+      if (input) input.value = assistantFieldValues.title || '';
+    }
+    if (assistantFieldValues.condition !== undefined) {
+      const input = document.querySelector('#condition');
+      if (input) input.value = assistantFieldValues.condition || '';
+    }
+    if (assistantFieldValues.included_items !== undefined) {
+      const input = document.querySelector('#included_items');
+      if (input) input.value = assistantFieldValues.included_items || '';
+    }
+    if (assistantFieldValues.description_html !== undefined) {
+      const input = document.querySelector('#description');
+      if (input) input.value = assistantFieldValues.description_html || '';
+    }
+    if (assistantFieldValues.category_suggestion !== undefined) {
+      const searchInput = document.querySelector('#category_search_query');
+      if (searchInput && assistantFieldValues.category_suggestion) searchInput.value = assistantFieldValues.category_suggestion;
+    }
+    if (assistantFieldValues.category_suggestion_id !== undefined) {
+      const categoryInput = document.querySelector('#category_suggestion');
+      if (categoryInput) categoryInput.value = assistantFieldValues.category_suggestion_id || '';
+    }
+  }
 
   const renderAssistantMessages = (messages) => {
     if (!assistantThread) return;
@@ -671,6 +700,7 @@
     if (!response.ok) return;
     const data = await response.json();
     assistantPendingField = data.pendingField || '';
+    syncAssistantFieldValues(data.fieldValues || {});
     clearAssistantActions();
     renderAssistantMessages(data.messages || []);
     if (!assistantPendingField) {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -40,115 +40,116 @@
 {% block title %}{{ app_name }} - Draft {{ draft.id }}{% endblock %}
 
 {% block content %}
-<section class="hero hero--landing hero--detail">
-  <div class="hero-landing__copy">
-    <p class="eyebrow">Artikelentwurf</p>
-    <h1>{{ draft.listing.title or result_summary.headline }}</h1>
-    <p class="hero-lead">{{ result_summary.body }}</p>
-    <p class="hero-support">Analyse: <strong>{{ analysis_state.label }}</strong> · Bilder: <strong>{{ draft.source.images | length }}</strong></p>
-    <div class="hero-actions hero-actions--split">
-      <a class="button button--primary" href="#{{ result_summary.primary_action_target }}">{{ result_summary.primary_action_label }}</a>
-      <a class="button button--secondary" href="/drafts">Zurück zur Übersicht</a>
-    </div>
-  </div>
-
-  <aside class="hero-landing__panel">
-    <p class="eyebrow">Nächster Schritt</p>
-    <div class="landing-metrics">
-      <div class="landing-metric">
-        <span>Status</span>
-        <strong>{{ display_status.label }}</strong>
-      </div>
-      <div class="landing-metric">
-        <span>eBay</span>
-        <strong>{{ marketplace_status_label }}</strong>
-      </div>
-      <div class="landing-metric landing-metric--wide">
-        <span>Kernangaben</span>
-        <strong>{{ review_state_label }}</strong>
-      </div>
-    </div>
-  </aside>
-</section>
-
-{% if missing_core_fields or marketplace_readiness_errors %}
-  <section class="notice-strip">
-    {% if missing_core_fields %}
-      <div class="notice notice--warning">
-        <h3>Noch vor dem Senden ergänzen</h3>
-        <ul>
-          {% for item in missing_core_fields %}
-            <li>{{ item }}</li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
-    {% if marketplace_readiness_errors %}
-      <div class="notice notice--warning">
-        <h3>eBay braucht noch</h3>
-        <ul>
-          {% for item in marketplace_readiness_errors %}
-            <li>{{ item }}</li>
-          {% endfor %}
-        </ul>
-        {% if marketplace_error_groups.setup %}
-          <div class="button-row button-row--single">
-            <a class="button button--secondary" href="/">eBay-Setup öffnen</a>
+<section class="mx-auto flex max-w-5xl flex-col gap-6 py-0 sm:py-8">
+  <div class="overflow-hidden bg-transparent sm:rounded-[2rem] sm:border sm:border-slate-200 sm:bg-white sm:shadow-soft">
+    <div class="bg-gradient-to-b from-slate-100 via-slate-50 to-white px-0 py-4 sm:px-6 sm:py-6">
+      <div class="flex min-h-[72vh] flex-col rounded-none bg-transparent sm:min-h-[46rem] sm:rounded-[1.75rem] sm:bg-white/70 sm:ring-1 sm:ring-slate-200/70">
+        <div class="flex items-center justify-between gap-3 px-0 pb-3 pt-2 sm:px-6">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700">Open Inserto</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-950">{{ draft.listing.title or result_summary.headline }}</h1>
+            <div class="mt-3 flex flex-wrap gap-2 text-xs font-medium text-slate-700">
+              <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">{{ analysis_state.label }}</span>
+              <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">{{ display_status.label }}</span>
+              <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">{{ marketplace_status_label }}</span>
+              <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">{{ review_state_label }}</span>
+            </div>
           </div>
-        {% elif marketplace_error_groups.item %}
-          <div class="button-row button-row--single">
-            <a class="button button--secondary" href="#listing-editor">Artikelangaben ergänzen</a>
+          <div class="flex flex-wrap items-center justify-end gap-2">
+            <a class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800" href="#{{ result_summary.primary_action_target }}">{{ result_summary.primary_action_label }}</a>
+            <a class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-950" href="/drafts">Zurück zur Übersicht</a>
           </div>
-        {% endif %}
-      </div>
-    {% endif %}
-  </section>
-{% endif %}
+        </div>
 
-<section class="card assistant-workflow border border-emerald-100 bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 text-white shadow-soft" id="assistant-flow" data-assistant-flow data-draft-id="{{ draft.id }}">
-  <div class="section-head section-head--compact">
-    <div>
-      <p class="eyebrow text-emerald-200">Assistenten-Flow</p>
-      <h2 class="text-white">Chat-artige Rückfragen ohne Reload</h2>
+        <div class="flex-1 space-y-4 overflow-y-auto px-0 pb-6 pt-2 sm:px-6" data-assistant-thread>
+          <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-4 text-white shadow-soft opacity-0 translate-y-4 transition duration-500" data-chat-node data-chat-static="true">
+            <div class="flex items-center gap-3">
+              <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg">✨</div>
+              <div>
+                <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
+                <p class="text-xs text-slate-400">soeben gesendet</p>
+              </div>
+            </div>
+            <p class="mt-3 text-sm leading-6 text-slate-100">{{ result_summary.body }}</p>
+          </article>
+
+          <article class="ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-4 text-emerald-950 shadow-sm opacity-0 translate-y-4 transition duration-500" data-chat-node data-chat-static="true">
+            <strong class="block text-sm font-semibold">Du</strong>
+            <div class="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {% for image in draft.source.images %}
+                <figure class="overflow-hidden rounded-[1.5rem] border border-emerald-200 bg-white/80 shadow-sm">
+                  <img class="h-40 w-full object-cover" src="/{{ image.storage_path }}" alt="{{ image.original_filename }}">
+                  <figcaption class="px-4 py-3 text-xs font-medium text-emerald-950/80">{{ image.order }}. {{ image.original_filename }}</figcaption>
+                </figure>
+              {% endfor %}
+            </div>
+            {% if original_input.get('notes') %}
+              <p class="mt-3 text-sm leading-6">{{ original_input.get('notes') }}</p>
+            {% endif %}
+          </article>
+
+          {% for message in assistant_flow.messages %}
+            <article class="{{ 'ml-auto border border-emerald-100 bg-emerald-400 text-emerald-950 shadow-sm' if message.role == 'user' else 'bg-slate-950 text-white shadow-soft' }} max-w-[92%] rounded-[1.75rem] px-5 py-4 {{ 'rounded-tr-sm' if message.role == 'user' else 'rounded-tl-sm' }} opacity-0 translate-y-4 transition duration-500{% if message.tone == 'confirmed' and message.role != 'user' %} ring-1 ring-emerald-300/40{% endif %}" data-chat-node>
+              <strong class="block text-sm font-semibold {{ 'text-emerald-950' if message.role == 'user' else 'text-emerald-200' }}">{{ 'Du' if message.role == 'user' else 'Open Inserto' }}</strong>
+              <p class="mt-3 text-sm leading-6 {{ 'text-emerald-950' if message.role == 'user' else 'text-slate-100' }}">{{ message.text }}</p>
+              {% if message.actions %}
+                <div class="mt-4 flex flex-wrap gap-2">
+                  {% for action in message.actions %}
+                    <button class="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition {{ 'bg-white text-slate-950 hover:bg-slate-100' if action.kind == 'edit' else 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300' }}" type="button" data-assistant-action="{{ action.kind }}" data-assistant-field="{{ action.field }}">{{ action.label }}</button>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
+
+        <form class="mx-0 mt-auto border-t border-slate-200/80 bg-white/90 px-4 py-4 backdrop-blur sm:mx-6 sm:mb-6 sm:rounded-[1.75rem] sm:border" data-assistant-composer hidden>
+          <label class="block">
+            <span class="mb-2 block text-sm font-medium text-slate-700" data-assistant-prompt>Antwort</span>
+            <textarea class="min-h-24 w-full rounded-2xl border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" name="value" rows="3" placeholder="Antwort hier eingeben"></textarea>
+          </label>
+          <div class="mt-3 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
+            <span>Der Ablauf bleibt hier im Chat. Das Formular darunter ist nur Fallback und Feinschliff.</span>
+            <button class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/20 transition hover:bg-slate-800" type="submit">Antwort senden</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
-  <p class="section-copy text-slate-200">Ich bestätige erkannte Angaben direkt im Verlauf und frage nur dort nach, wo für den Entwurf noch etwas fehlt.</p>
-  <div class="mb-5 flex items-center gap-4 rounded-3xl border border-white/10 bg-white/5 px-4 py-4">
-    <div class="relative h-12 w-12 shrink-0">
-      <span class="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping"></span>
-      <span class="absolute inset-1 rounded-full bg-emerald-400/30 animate-pulse"></span>
-      <span class="absolute inset-[10px] rounded-full bg-emerald-400"></span>
-    </div>
-    <div>
-      <p class="text-sm font-semibold text-white">Analyse läuft im Hintergrund</p>
-      <p class="text-sm text-slate-300">Erkannte Angaben werden hier direkt bestätigt oder korrigiert.</p>
-    </div>
-  </div>
-  <div class="assistant-thread" data-assistant-thread>
-    {% for message in assistant_flow.messages %}
-      <article class="assistant-bubble assistant-bubble--{{ 'user' if message.role == 'user' else 'assistant' }}{% if message.tone == 'confirmed' %} assistant-bubble--confirmed{% endif %}">
-        <strong>{{ 'Du' if message.role == 'user' else 'Open Inserto' }}</strong>
-        <p>{{ message.text }}</p>
-        {% if message.actions %}
-          <div class="assistant-choice-row">
-            {% for action in message.actions %}
-              <button class="assistant-choice {% if action.kind == 'edit' %}assistant-choice--secondary{% endif %}" type="button" data-assistant-action="{{ action.kind }}" data-assistant-field="{{ action.field }}">{{ action.label }}</button>
+
+  {% if missing_core_fields or marketplace_readiness_errors %}
+    <section class="grid gap-4 lg:grid-cols-2">
+      {% if missing_core_fields %}
+        <div class="rounded-[1.75rem] border border-amber-200 bg-amber-50 px-5 py-4 text-amber-950 shadow-sm">
+          <h2 class="text-base font-semibold">Noch vor dem Senden ergänzen</h2>
+          <ul class="mt-3 list-disc space-y-1 pl-5 text-sm">
+            {% for item in missing_core_fields %}
+              <li>{{ item }}</li>
             {% endfor %}
-          </div>
-        {% endif %}
-      </article>
-    {% endfor %}
-  </div>
-  <form class="assistant-composer rounded-3xl border border-white/10 bg-white/5 p-4" data-assistant-composer hidden>
-    <label class="field field--full">
-      <span class="text-slate-100" data-assistant-prompt>Antwort</span>
-      <textarea class="rounded-2xl border-white/10 bg-slate-950 text-white placeholder:text-slate-400" name="value" rows="3" placeholder="Antwort hier eingeben"></textarea>
-    </label>
-    <div class="button-row button-row--single">
-      <button class="button button--primary" type="submit">Antwort senden</button>
-    </div>
-  </form>
-</section>
+          </ul>
+        </div>
+      {% endif %}
+      {% if marketplace_readiness_errors %}
+        <div class="rounded-[1.75rem] border border-amber-200 bg-amber-50 px-5 py-4 text-amber-950 shadow-sm">
+          <h2 class="text-base font-semibold">eBay braucht noch</h2>
+          <ul class="mt-3 list-disc space-y-1 pl-5 text-sm">
+            {% for item in marketplace_readiness_errors %}
+              <li>{{ item }}</li>
+            {% endfor %}
+          </ul>
+          {% if marketplace_error_groups.setup %}
+            <div class="mt-4">
+              <a class="inline-flex items-center justify-center rounded-2xl border border-amber-300 bg-white px-4 py-2 text-sm font-semibold text-amber-950 shadow-sm" href="/">eBay-Setup öffnen</a>
+            </div>
+          {% elif marketplace_error_groups.item %}
+            <div class="mt-4">
+              <a class="inline-flex items-center justify-center rounded-2xl border border-amber-300 bg-white px-4 py-2 text-sm font-semibold text-amber-950 shadow-sm" href="#listing-editor">Artikelangaben ergänzen</a>
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
 
 <section class="listing-workbench">
   <aside class="workbench-side">
@@ -521,12 +522,27 @@
   </details>
 </section>
 <script>
-  const assistantRoot = document.querySelector('[data-assistant-flow]');
-  const assistantThread = assistantRoot?.querySelector('[data-assistant-thread]');
-  const assistantComposer = assistantRoot?.querySelector('[data-assistant-composer]');
-  const assistantPrompt = assistantRoot?.querySelector('[data-assistant-prompt]');
+  const assistantRoot = document.body;
+  const assistantThread = document.querySelector('[data-assistant-thread]');
+  const assistantComposer = document.querySelector('[data-assistant-composer]');
+  const assistantPrompt = document.querySelector('[data-assistant-prompt]');
   const assistantInput = assistantComposer?.querySelector('textarea[name="value"]');
+  const draftId = '{{ draft.id }}';
   let assistantPendingField = '{{ assistant_flow.pendingField }}';
+
+  function scrollThreadToBottom(behavior = 'smooth') {
+    assistantThread?.lastElementChild?.scrollIntoView({ behavior, block: 'end' });
+  }
+
+  function revealChatNodes() {
+    const nodes = Array.from(document.querySelectorAll('[data-chat-node]'));
+    nodes.forEach((node, index) => {
+      window.setTimeout(() => {
+        node.classList.remove('opacity-0', 'translate-y-4');
+        scrollThreadToBottom(index === 0 ? 'auto' : 'smooth');
+      }, Math.min(index * 110, 1200));
+    });
+  }
 
   const assistantFieldLabel = (field) => {
     if (field === 'description_html') return 'Beschreibung';
@@ -537,23 +553,28 @@
 
   const renderAssistantMessages = (messages) => {
     if (!assistantThread) return;
+    const persistentNodes = Array.from(assistantThread.querySelectorAll('[data-chat-static="true"]'));
     assistantThread.innerHTML = '';
+    persistentNodes.forEach((node) => assistantThread.appendChild(node));
     messages.forEach((message) => {
       const article = document.createElement('article');
-      article.className = `assistant-bubble assistant-bubble--${message.role === 'user' ? 'user' : 'assistant'}${message.tone === 'confirmed' ? ' assistant-bubble--confirmed' : ''}`;
+      article.dataset.chatNode = 'true';
+      article.className = `${message.role === 'user' ? 'ml-auto border border-emerald-100 bg-emerald-400 text-emerald-950 shadow-sm rounded-tr-sm' : 'bg-slate-950 text-white shadow-soft rounded-tl-sm'} max-w-[92%] rounded-[1.75rem] px-5 py-4 opacity-0 translate-y-4 transition duration-500${message.tone === 'confirmed' && message.role !== 'user' ? ' ring-1 ring-emerald-300/40' : ''}`;
       const strong = document.createElement('strong');
+      strong.className = `block text-sm font-semibold ${message.role === 'user' ? 'text-emerald-950' : 'text-emerald-200'}`;
       strong.textContent = message.role === 'user' ? 'Du' : 'Open Inserto';
       article.appendChild(strong);
       const text = document.createElement('p');
+      text.className = `mt-3 text-sm leading-6 ${message.role === 'user' ? 'text-emerald-950' : 'text-slate-100'}`;
       text.textContent = message.text;
       article.appendChild(text);
       if (Array.isArray(message.actions) && message.actions.length) {
         const row = document.createElement('div');
-        row.className = 'assistant-choice-row';
+        row.className = 'mt-4 flex flex-wrap gap-2';
         message.actions.forEach((action) => {
           const button = document.createElement('button');
           button.type = 'button';
-          button.className = `assistant-choice${action.kind === 'edit' ? ' assistant-choice--secondary' : ''}`;
+          button.className = `inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition ${action.kind === 'edit' ? 'bg-white text-slate-950 hover:bg-slate-100' : 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300'}`;
           button.dataset.assistantAction = action.kind;
           button.dataset.assistantField = action.field;
           button.textContent = action.label;
@@ -562,12 +583,16 @@
         article.appendChild(row);
       }
       assistantThread.appendChild(article);
+      window.requestAnimationFrame(() => {
+        article.classList.remove('opacity-0', 'translate-y-4');
+        scrollThreadToBottom();
+      });
     });
   };
 
   const sendAssistantAction = async (payload) => {
     if (!assistantRoot) return;
-    const response = await fetch(`/drafts/${assistantRoot.dataset.draftId}/assistant/message`, {
+    const response = await fetch(`/drafts/${draftId}/assistant/message`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -799,6 +824,8 @@
     });
   }
 
+  revealChatNodes();
+  scrollThreadToBottom('auto');
   initializeSearchableSelects();
 </script>
 {% endblock %}

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -95,7 +95,11 @@
               {% if message.actions %}
                 <div class="mt-4 flex flex-wrap gap-2">
                   {% for action in message.actions %}
-                    <button class="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition {{ 'bg-white text-slate-950 hover:bg-slate-100' if action.kind == 'edit' else 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300' }}" type="button" data-assistant-action="{{ action.kind }}" data-assistant-field="{{ action.field }}">{{ action.label }}</button>
+                    {% if action.kind == 'link' and action.href %}
+                      <a class="inline-flex items-center justify-center rounded-2xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-300" href="{{ action.href }}">{{ action.label }}</a>
+                    {% else %}
+                      <button class="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition {{ 'bg-white text-slate-950 hover:bg-slate-100' if action.kind == 'edit' else 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300' }}" type="button" data-assistant-action="{{ action.kind }}" data-assistant-field="{{ action.field }}"{% if action.value %} data-assistant-value="{{ action.value }}"{% endif %}>{{ action.label }}</button>
+                    {% endif %}
                   {% endfor %}
                 </div>
               {% endif %}
@@ -110,7 +114,10 @@
           </label>
           <div class="mt-3 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
             <span>Der Ablauf bleibt hier im Chat. Das Formular darunter ist nur Fallback und Feinschliff.</span>
-            <button class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/20 transition hover:bg-slate-800" type="submit">Antwort senden</button>
+            <div class="flex items-center gap-3">
+              <button class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-950" type="button" data-assistant-clear>Leeren</button>
+              <button class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/20 transition hover:bg-slate-800" type="submit">Antwort senden</button>
+            </div>
           </div>
         </form>
       </div>
@@ -534,6 +541,21 @@
     assistantThread?.lastElementChild?.scrollIntoView({ behavior, block: 'end' });
   }
 
+  const messageSignature = (message) => JSON.stringify({
+    role: message.role,
+    text: message.text,
+    tone: message.tone || '',
+    actions: Array.isArray(message.actions)
+      ? message.actions.map((action) => ({
+          kind: action.kind,
+          label: action.label,
+          field: action.field || '',
+          value: action.value || '',
+          href: action.href || '',
+        }))
+      : [],
+  });
+
   function revealChatNodes() {
     const nodes = Array.from(document.querySelectorAll('[data-chat-node]'));
     nodes.forEach((node, index) => {
@@ -553,14 +575,47 @@
     return 'Produktname';
   };
 
+  const assistantFieldCurrentValue = (field) => {
+    if (field === 'title') return document.querySelector('#title')?.value || '';
+    if (field === 'condition') return document.querySelector('#condition')?.value || '';
+    if (field === 'included_items') return document.querySelector('#included_items')?.value || '';
+    if (field === 'description_html') return document.querySelector('#description')?.value || '';
+    if (field === 'category_suggestion') {
+      return document.querySelector('#category_search_query')?.value || document.querySelector('#category_suggestion')?.value || '';
+    }
+    if (field?.startsWith('ebay_aspect::')) {
+      const aspectName = field.replace('ebay_aspect::', '');
+      const escaped = window.CSS?.escape ? CSS.escape(aspectName) : aspectName.replaceAll('"', '\\"');
+      return document.querySelector(`[name="ebay_aspect__${escaped}"]`)?.value || '';
+    }
+    return '';
+  };
+
   const renderAssistantMessages = (messages) => {
     if (!assistantThread) return;
-    const persistentNodes = Array.from(assistantThread.querySelectorAll('[data-chat-static="true"]'));
-    assistantThread.innerHTML = '';
-    persistentNodes.forEach((node) => assistantThread.appendChild(node));
-    messages.forEach((message) => {
+    const renderedNodes = Array.from(assistantThread.querySelectorAll('[data-chat-node]:not([data-chat-static="true"])'));
+    const renderedSignatures = renderedNodes.map((node) => node.dataset.messageSignature || '');
+    const nextSignatures = messages.map((message) => messageSignature(message));
+
+    let prefixLength = 0;
+    while (
+      prefixLength < renderedSignatures.length &&
+      prefixLength < nextSignatures.length &&
+      renderedSignatures[prefixLength] === nextSignatures[prefixLength]
+    ) {
+      prefixLength += 1;
+    }
+
+    if (prefixLength !== renderedSignatures.length) {
+      renderedNodes.forEach((node, index) => {
+        if (index >= prefixLength) node.remove();
+      });
+    }
+
+    messages.slice(prefixLength).forEach((message) => {
       const article = document.createElement('article');
       article.dataset.chatNode = 'true';
+      article.dataset.messageSignature = messageSignature(message);
       article.className = `${message.role === 'user' ? 'ml-auto border border-emerald-100 bg-emerald-400 text-emerald-950 shadow-sm rounded-tr-sm' : 'bg-slate-950 text-white shadow-soft rounded-tl-sm'} max-w-[92%] rounded-[1.75rem] px-5 py-4 opacity-0 translate-y-4 transition duration-500${message.tone === 'confirmed' && message.role !== 'user' ? ' ring-1 ring-emerald-300/40' : ''}`;
       const strong = document.createElement('strong');
       strong.className = `block text-sm font-semibold ${message.role === 'user' ? 'text-emerald-950' : 'text-emerald-200'}`;
@@ -574,6 +629,14 @@
         const row = document.createElement('div');
         row.className = 'mt-4 flex flex-wrap gap-2';
         message.actions.forEach((action) => {
+          if (action.kind === 'link' && action.href) {
+            const link = document.createElement('a');
+            link.href = action.href;
+            link.className = 'inline-flex items-center justify-center rounded-2xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-300';
+            link.textContent = action.label;
+            row.appendChild(link);
+            return;
+          }
           const button = document.createElement('button');
           button.type = 'button';
           button.className = `inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition ${action.kind === 'edit' ? 'bg-white text-slate-950 hover:bg-slate-100' : 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300'}`;
@@ -610,6 +673,12 @@
   };
 
   assistantRoot?.addEventListener('click', async (event) => {
+    const clearButton = event.target.closest('[data-assistant-clear]');
+    if (clearButton) {
+      if (assistantInput) assistantInput.value = '';
+      assistantInput?.focus();
+      return;
+    }
     const button = event.target.closest('[data-assistant-action]');
     if (!button) return;
     const action = button.dataset.assistantAction;
@@ -619,7 +688,11 @@
       assistantPendingField = field;
       assistantComposer?.removeAttribute('hidden');
       if (assistantPrompt) assistantPrompt.textContent = `${assistantFieldLabel(field)} eingeben`;
+      if (assistantInput) {
+        assistantInput.value = assistantFieldCurrentValue(field);
+      }
       assistantInput?.focus();
+      assistantInput?.setSelectionRange?.(assistantInput.value.length, assistantInput.value.length);
       return;
     }
     await sendAssistantAction({ action, field, value });

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -91,7 +91,7 @@
           {% for message in assistant_flow.messages %}
             <article class="{{ 'ml-auto border border-emerald-100 bg-emerald-400 text-emerald-950 shadow-sm' if message.role == 'user' else 'bg-slate-950 text-white shadow-soft' }} max-w-[92%] rounded-[1.75rem] px-5 py-4 {{ 'rounded-tr-sm' if message.role == 'user' else 'rounded-tl-sm' }} opacity-0 translate-y-4 transition duration-500{% if message.tone == 'confirmed' and message.role != 'user' %} ring-1 ring-emerald-300/40{% endif %}" data-chat-node>
               <strong class="block text-sm font-semibold {{ 'text-emerald-950' if message.role == 'user' else 'text-emerald-200' }}">{{ 'Du' if message.role == 'user' else 'Open Inserto' }}</strong>
-              <p class="mt-3 text-sm leading-6 {{ 'text-emerald-950' if message.role == 'user' else 'text-slate-100' }}">{{ message.text }}</p>
+              <p class="mt-3 whitespace-pre-line text-sm leading-6 {{ 'text-emerald-950' if message.role == 'user' else 'text-slate-100' }}">{{ message.text }}</p>
               {% if message.actions %}
                 <div class="mt-4 flex flex-wrap gap-2" data-assistant-actions>
                   {% for action in message.actions %}
@@ -622,7 +622,7 @@
       strong.textContent = message.role === 'user' ? 'Du' : 'Open Inserto';
       article.appendChild(strong);
       const text = document.createElement('p');
-      text.className = `mt-3 text-sm leading-6 ${message.role === 'user' ? 'text-emerald-950' : 'text-slate-100'}`;
+      text.className = `mt-3 whitespace-pre-line text-sm leading-6 ${message.role === 'user' ? 'text-emerald-950' : 'text-slate-100'}`;
       text.textContent = message.text;
       article.appendChild(text);
       if (Array.isArray(message.actions) && message.actions.length) {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -93,7 +93,7 @@
               <strong class="block text-sm font-semibold {{ 'text-emerald-950' if message.role == 'user' else 'text-emerald-200' }}">{{ 'Du' if message.role == 'user' else 'Open Inserto' }}</strong>
               <p class="mt-3 text-sm leading-6 {{ 'text-emerald-950' if message.role == 'user' else 'text-slate-100' }}">{{ message.text }}</p>
               {% if message.actions %}
-                <div class="mt-4 flex flex-wrap gap-2">
+                <div class="mt-4 flex flex-wrap gap-2" data-assistant-actions>
                   {% for action in message.actions %}
                     {% if action.kind == 'link' and action.href %}
                       <a class="inline-flex items-center justify-center rounded-2xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-300" href="{{ action.href }}">{{ action.label }}</a>
@@ -628,6 +628,7 @@
       if (Array.isArray(message.actions) && message.actions.length) {
         const row = document.createElement('div');
         row.className = 'mt-4 flex flex-wrap gap-2';
+        row.dataset.assistantActions = 'true';
         message.actions.forEach((action) => {
           if (action.kind === 'link' && action.href) {
             const link = document.createElement('a');
@@ -656,6 +657,10 @@
     });
   };
 
+  const clearAssistantActions = () => {
+    assistantThread?.querySelectorAll('[data-assistant-actions]').forEach((node) => node.remove());
+  };
+
   const sendAssistantAction = async (payload) => {
     if (!assistantRoot) return;
     const response = await fetch(`/drafts/${draftId}/assistant/message`, {
@@ -666,6 +671,7 @@
     if (!response.ok) return;
     const data = await response.json();
     assistantPendingField = data.pendingField || '';
+    clearAssistantActions();
     renderAssistantMessages(data.messages || []);
     if (!assistantPendingField) {
       assistantComposer?.setAttribute('hidden', 'hidden');

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -545,6 +545,8 @@
   }
 
   const assistantFieldLabel = (field) => {
+    if (field === 'category_suggestion') return 'eBay-Kategorie';
+    if (field?.startsWith('ebay_aspect::')) return field.replace('ebay_aspect::', '');
     if (field === 'description_html') return 'Beschreibung';
     if (field === 'included_items') return 'Lieferumfang';
     if (field === 'condition') return 'Zustand';
@@ -577,6 +579,7 @@
           button.className = `inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition ${action.kind === 'edit' ? 'bg-white text-slate-950 hover:bg-slate-100' : 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300'}`;
           button.dataset.assistantAction = action.kind;
           button.dataset.assistantField = action.field;
+          if (action.value) button.dataset.assistantValue = action.value;
           button.textContent = action.label;
           row.appendChild(button);
         });
@@ -611,6 +614,7 @@
     if (!button) return;
     const action = button.dataset.assistantAction;
     const field = button.dataset.assistantField;
+    const value = button.dataset.assistantValue || '';
     if (action === 'edit') {
       assistantPendingField = field;
       assistantComposer?.removeAttribute('hidden');
@@ -618,7 +622,7 @@
       assistantInput?.focus();
       return;
     }
-    await sendAssistantAction({ action, field });
+    await sendAssistantAction({ action, field, value });
   });
 
   assistantComposer?.addEventListener('submit', async (event) => {

--- a/app/templates/draft_detail.html
+++ b/app/templates/draft_detail.html
@@ -111,9 +111,8 @@
       <p class="eyebrow text-emerald-200">Assistenten-Flow</p>
       <h2 class="text-white">Chat-artige Rückfragen ohne Reload</h2>
     </div>
-    <span class="status-chip status-chip--muted border-white/10 bg-white/10 text-white">Beta</span>
   </div>
-  <p class="section-copy text-slate-200">Der Assistent bestätigt erkannte Angaben direkt im Verlauf, zeigt eine sichtbare Analysephase und fragt fehlende Kerninfos schrittweise nach.</p>
+  <p class="section-copy text-slate-200">Ich bestätige erkannte Angaben direkt im Verlauf und frage nur dort nach, wo für den Entwurf noch etwas fehlt.</p>
   <div class="mb-5 flex items-center gap-4 rounded-3xl border border-white/10 bg-white/5 px-4 py-4">
     <div class="relative h-12 w-12 shrink-0">
       <span class="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping"></span>
@@ -121,8 +120,8 @@
       <span class="absolute inset-[10px] rounded-full bg-emerald-400"></span>
     </div>
     <div>
-      <p class="text-sm font-semibold text-white">AI-Analyse aktiv</p>
-      <p class="text-sm text-slate-300">Erkannte Angaben werden im Gespräch bestätigt oder direkt korrigiert.</p>
+      <p class="text-sm font-semibold text-white">Analyse läuft im Hintergrund</p>
+      <p class="text-sm text-slate-300">Erkannte Angaben werden hier direkt bestätigt oder korrigiert.</p>
     </div>
   </div>
   <div class="assistant-thread" data-assistant-thread>

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -3,93 +3,94 @@
 {% block title %}{{ app_name }} – Upload{% endblock %}
 
 {% block content %}
-<section class="mx-auto flex max-w-5xl flex-col gap-6 py-6 sm:py-10">
-  <div class="overflow-hidden rounded-[2rem] border border-slate-200 bg-white shadow-soft">
-    <div class="border-b border-slate-200 bg-slate-950 px-5 py-5 text-white sm:px-8">
-      <h1 class="text-3xl font-semibold tracking-tight sm:text-4xl">Bilder hochladen</h1>
-      <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">
-        Starte einfach mit Fotos. Danach fragt dich der Assistent nur noch das, was für ein gutes Angebot wirklich noch fehlt.
-      </p>
-    </div>
-
-    <div class="space-y-5 bg-gradient-to-b from-slate-100/70 to-white px-4 py-5 sm:px-6 sm:py-6">
-      <article class="max-w-[90%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-4 text-white shadow-soft">
-        <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-200">Open Inserto</strong>
-        <p class="mt-2 text-sm leading-6 text-slate-100">Hi, lade zuerst deine Bilder hoch. Ich erkenne Produkt, Zustand und wichtige Merkmale und melde mich danach mit passenden Rückfragen oder Auswahlbuttons.</p>
-      </article>
-
-      {% if errors %}
-        <div class="max-w-[90%] rounded-[1.5rem] rounded-tl-sm border border-rose-200 bg-rose-50 px-5 py-4 text-rose-900 shadow-sm">
-          <strong class="block text-sm font-semibold">Upload fehlgeschlagen.</strong>
-          <ul class="mt-2 list-disc space-y-1 pl-5 text-sm">
-            {% for error in errors %}
-              <li>{{ error }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endif %}
-
-      <form class="space-y-5" method="post" action="/drafts/upload" enctype="multipart/form-data" data-assistant-upload-form>
-        <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm border border-slate-200 bg-white px-5 py-5 shadow-sm">
-          <strong class="block text-sm font-semibold text-slate-900">Open Inserto</strong>
-          <p class="mt-2 text-sm leading-6 text-slate-600">Schick mir die Fotos. Du kannst mehrere Bilder direkt auf einmal hochladen.</p>
-          <p class="mt-3 text-sm font-medium text-slate-900">Mehrfach-Upload mit Vorschau</p>
-
-          <label class="group mt-4 block rounded-[1.5rem] border border-dashed border-emerald-300 bg-emerald-50/70 p-6 transition hover:border-emerald-500 hover:bg-emerald-50" data-dropzone>
-            <input class="sr-only" type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
-            <div class="flex flex-col items-center justify-center gap-3 text-center">
-              <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm ring-1 ring-emerald-100">📸</div>
-              <div>
-                <p class="text-base font-semibold text-slate-900">Dateien auswählen</p>
-                <p class="mt-1 text-sm text-slate-600">Oder Bilder einfach hier hineinziehen</p>
-              </div>
-              <div class="flex flex-wrap justify-center gap-2 text-xs text-slate-500">
-                <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 1 Bild</span>
-                <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Maximal 20 Bilder</span>
-                <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 500 px</span>
-              </div>
+<section class="mx-auto flex max-w-4xl flex-col py-0 sm:py-8">
+  <div class="overflow-hidden bg-transparent sm:rounded-[2rem] sm:border sm:border-slate-200 sm:bg-white sm:shadow-soft">
+    <div class="space-y-4 bg-gradient-to-b from-slate-100 via-slate-50 to-white px-0 py-4 sm:px-6 sm:py-6">
+      <div class="space-y-4" data-chat-sequence>
+        <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-4 text-white shadow-soft opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
+          <div class="flex items-center gap-3">
+            <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg">✨</div>
+            <div>
+              <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
+              <p class="text-xs text-slate-400">schreibt gerade</p>
             </div>
-          </label>
-
-          <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-preview-grid>
-            <p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>
           </div>
+          <div class="mt-3 flex items-center gap-2 text-emerald-200" data-typing-indicator>
+            <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce [animation-delay:-0.3s]"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce [animation-delay:-0.15s]"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce"></span>
+          </div>
+          <p class="mt-3 hidden text-sm leading-6 text-slate-100" data-chat-text>Hi, lade zuerst deine Bilder hoch. Ich speichere sie erst einmal intern und gehe danach mit dir Schritt für Schritt durch die nächsten Infos.</p>
         </article>
 
-        <article class="ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-5 text-emerald-950 shadow-sm">
-          <strong class="block text-sm font-semibold">Du</strong>
-          <p class="mt-2 text-sm leading-6">Wenn du magst, gib mir direkt noch ein paar Hinweise mit. Das spart später Rückfragen.</p>
+        {% if errors %}
+          <div class="max-w-[92%] rounded-[1.5rem] rounded-tl-sm border border-rose-200 bg-rose-50 px-5 py-4 text-rose-900 shadow-sm">
+            <strong class="block text-sm font-semibold">Upload fehlgeschlagen.</strong>
+            <ul class="mt-2 list-disc space-y-1 pl-5 text-sm">
+              {% for error in errors %}
+                <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
 
-          <div class="mt-4 grid gap-4">
-            <label class="block">
-              <span class="mb-2 block text-sm font-medium">Was soll ich über den Artikel schon wissen?</span>
-              <textarea class="min-h-28 w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Preisidee, Fundort ...">{{ form_values.notes or '' }}</textarea>
+        <form class="space-y-4" method="post" action="/drafts/upload" enctype="multipart/form-data" data-assistant-upload-form>
+          <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm border border-slate-200 bg-white px-5 py-5 shadow-sm opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
+            <strong class="block text-sm font-semibold text-slate-900">Open Inserto</strong>
+            <p class="mt-2 text-sm leading-6 text-slate-600">Schick mir jetzt die Fotos. Wichtig: Die Bilder werden hier erst einmal nur hochgeladen, noch nicht direkt analysiert.</p>
+
+            <label class="group mt-4 block rounded-[1.5rem] border border-dashed border-emerald-300 bg-emerald-50/70 p-6 transition hover:border-emerald-500 hover:bg-emerald-50" data-dropzone>
+              <input class="sr-only" type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
+              <div class="flex flex-col items-center justify-center gap-3 text-center">
+                <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm ring-1 ring-emerald-100">📸</div>
+                <div>
+                  <p class="text-base font-semibold text-slate-900">Bilder hochladen</p>
+                  <p class="mt-1 text-sm text-slate-600">Oder Bilder einfach hier hineinziehen</p>
+                </div>
+                <div class="flex flex-wrap justify-center gap-2 text-xs text-slate-500">
+                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 1 Bild</span>
+                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Maximal 20 Bilder</span>
+                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 500 px</span>
+                </div>
+              </div>
             </label>
 
-            <div class="grid gap-4 md:grid-cols-2">
-              {% for field_name, field_label in extra_fields %}
-                <label class="block">
-                  <span class="mb-2 block text-sm font-medium">{{ field_label }}</span>
-                  <input class="w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
-                </label>
-              {% endfor %}
+            <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-preview-grid>
+              <p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>
             </div>
-          </div>
-        </article>
+          </article>
 
-        <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-5 text-white shadow-soft">
-          <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
-          <p class="mt-2 text-sm leading-6 text-slate-100">Sobald du auf <strong>Draft erstellen</strong> tippst, starte ich direkt mit der Analyse und öffne danach den Gesprächsverlauf für die nächsten Fragen.</p>
-          <div class="mt-4 flex items-center gap-3 text-sm text-slate-300">
-            <span class="relative flex h-3 w-3">
-              <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-300 opacity-75"></span>
-              <span class="relative inline-flex h-3 w-3 rounded-full bg-emerald-300"></span>
-            </span>
-            <span>Sichtbare Analyse statt leerer Wartezeit</span>
-          </div>
-          <button class="mt-5 inline-flex items-center justify-center rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300" type="submit" data-submit-button>Draft erstellen</button>
-        </article>
-      </form>
+          <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-5 text-white shadow-soft opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
+            <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
+            <p class="mt-2 text-sm leading-6 text-slate-100">Wenn du magst, gib mir direkt noch ein paar Hinweise mit. Das spart später Rückfragen.</p>
+          </article>
+
+          <article class="ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-5 text-emerald-950 shadow-sm opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
+            <strong class="block text-sm font-semibold">Du</strong>
+
+            <div class="mt-4 grid gap-4">
+              <label class="block">
+                <span class="mb-2 block text-sm font-medium">Was soll ich über den Artikel schon wissen?</span>
+                <textarea class="min-h-28 w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Preisidee, Fundort ...">{{ form_values.notes or '' }}</textarea>
+              </label>
+
+              <div class="grid gap-4 md:grid-cols-2">
+                {% for field_name, field_label in extra_fields %}
+                  <label class="block">
+                    <span class="mb-2 block text-sm font-medium">{{ field_label }}</span>
+                    <input class="w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
+                  </label>
+                {% endfor %}
+              </div>
+
+              <div class="flex flex-wrap items-center justify-end gap-3">
+                <span class="text-sm text-emerald-900/80">Antwort wird zusammen mit deinen Bildern gesendet.</span>
+                <button class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/20 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-950/30" type="submit" data-submit-button>Bilder senden</button>
+              </div>
+            </div>
+          </article>
+        </form>
+      </div>
     </div>
   </div>
 
@@ -129,6 +130,23 @@
   const analysisOverlay = document.querySelector('[data-analysis-overlay]');
   const submitButton = document.querySelector('[data-submit-button]');
 
+  const revealChat = () => {
+    const steps = document.querySelectorAll('[data-chat-step]');
+    steps.forEach((step, index) => {
+      window.setTimeout(() => {
+        step.dataset.visible = 'true';
+        const typingIndicator = step.querySelector('[data-typing-indicator]');
+        const text = step.querySelector('[data-chat-text]');
+        if (typingIndicator && text) {
+          window.setTimeout(() => {
+            typingIndicator.classList.add('hidden');
+            text.classList.remove('hidden');
+          }, 900);
+        }
+      }, index * 260);
+    });
+  };
+
   const renderPreviews = () => {
     const files = Array.from(input.files || []);
     if (!files.length) {
@@ -158,7 +176,7 @@
 
       const badge = document.createElement('span');
       badge.className = 'rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-medium text-emerald-800';
-      badge.textContent = 'Bereit';
+      badge.textContent = 'Hochgeladen';
       header.appendChild(badge);
       item.appendChild(header);
 
@@ -175,6 +193,7 @@
     });
   };
 
+  revealChat();
   input?.addEventListener('change', renderPreviews);
 
   ['dragenter', 'dragover'].forEach((eventName) => {

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -142,7 +142,24 @@
   let uploadStepMounted = false;
   let notesStepMounted = false;
   let currentDraftId = null;
+  let currentDraftLocation = '';
   let assistantPendingField = '';
+
+  const escapeHtml = (value) => String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
+  const assistantFieldCurrentValue = (field) => {
+    if (field === 'title') return uploadForm?.querySelector('[data-extra-input="product_name"]')?.value || '';
+    if (field === 'condition') return uploadForm?.querySelector('[data-extra-input="condition"]')?.value || '';
+    if (field === 'included_items') return uploadForm?.querySelector('[data-extra-input="accessories"]')?.value || '';
+    if (field === 'description_html') return notesInput?.value || '';
+    if (field === 'category_suggestion') return '';
+    return '';
+  };
 
   const syncFileInput = (files) => {
     if (!realInput) return;
@@ -208,9 +225,11 @@
   };
 
   const renderAssistantMessages = async (messages) => {
+    chatThread?.querySelectorAll('[data-assistant-actions]').forEach((node) => node.remove());
+
     for (const message of messages) {
       if (message.role === 'user') {
-        appendUserMessage(`<p>${message.text}</p>`);
+        appendUserMessage(`<p>${escapeHtml(message.text)}</p>`);
         continue;
       }
 
@@ -220,7 +239,17 @@
 
       const row = document.createElement('div');
       row.className = 'mt-4 flex flex-wrap gap-2';
+      row.dataset.assistantActions = 'true';
       message.actions.forEach((action) => {
+        if (action.kind === 'link' && action.href) {
+          const link = document.createElement('a');
+          const targetExists = action.href.startsWith('#') && document.querySelector(action.href);
+          link.href = targetExists ? action.href : `${currentDraftLocation || `/drafts/${currentDraftId || ''}`}${action.href}`;
+          link.className = 'inline-flex items-center justify-center rounded-2xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-300';
+          link.textContent = action.label;
+          row.appendChild(link);
+          return;
+        }
         const button = document.createElement('button');
         button.type = 'button';
         button.className = `inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition ${action.kind === 'edit' ? 'bg-white text-slate-950 hover:bg-slate-100' : 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300'}`;
@@ -251,6 +280,7 @@
       </div>
     `;
     const textarea = wrapper.querySelector('textarea');
+    textarea.value = assistantFieldCurrentValue(field);
     const button = wrapper.querySelector('button');
     button.addEventListener('click', async () => {
       if (!textarea.value.trim()) return;
@@ -366,6 +396,7 @@
 
       const data = await response.json();
       currentDraftId = data.draftId;
+      currentDraftLocation = data.location || `/drafts/${data.draftId}`;
       assistantPendingField = data.assistant?.pendingField || '';
       if (data.location) {
         window.history.replaceState({}, '', data.location);

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -170,6 +170,8 @@
 
   const assistantFieldCurrentValue = (field) => {
     if (assistantFieldValues[field]) return assistantFieldValues[field];
+    if (field === 'included_items' && assistantFieldValues.included_items) return assistantFieldValues.included_items;
+    if (field === 'description_html' && assistantFieldValues.description_html) return assistantFieldValues.description_html;
     if (field === 'title') return uploadForm?.querySelector('[data-extra-input="product_name"]')?.value || '';
     if (field === 'condition') return uploadForm?.querySelector('[data-extra-input="condition"]')?.value || '';
     if (field === 'included_items') return uploadForm?.querySelector('[data-extra-input="accessories"]')?.value || '';
@@ -228,6 +230,21 @@
     return node;
   };
 
+  const syncAssistantFieldValues = (fieldValues) => {
+    assistantFieldValues = fieldValues || assistantFieldValues;
+    const productName = uploadForm?.querySelector('[data-extra-input="product_name"]');
+    const condition = uploadForm?.querySelector('[data-extra-input="condition"]');
+    const accessories = uploadForm?.querySelector('[data-extra-input="accessories"]');
+    if (productName && assistantFieldValues.title !== undefined) productName.value = assistantFieldValues.title || '';
+    if (condition && assistantFieldValues.condition !== undefined) condition.value = assistantFieldValues.condition || '';
+    if (accessories && assistantFieldValues.included_items !== undefined) accessories.value = assistantFieldValues.included_items || '';
+    if (notesInput && assistantFieldValues.description_html !== undefined) notesInput.value = assistantFieldValues.description_html || '';
+  };
+
+  const clearAssistantActions = () => {
+    chatThread?.querySelectorAll('[data-assistant-actions]').forEach((node) => node.remove());
+  };
+
   const sendAssistantAction = async (payload) => {
     if (!currentDraftId) return;
     const response = await fetch(`/drafts/${currentDraftId}/assistant/message`, {
@@ -238,7 +255,8 @@
     if (!response.ok) return;
     const data = await response.json();
     assistantPendingField = data.pendingField || '';
-    assistantFieldValues = data.fieldValues || assistantFieldValues;
+    syncAssistantFieldValues(data.fieldValues || {});
+    clearAssistantActions();
     await renderAssistantMessages(data.messages || []);
   };
 
@@ -432,7 +450,7 @@
       currentDraftId = data.draftId;
       currentDraftLocation = data.location || `/drafts/${data.draftId}`;
       assistantPendingField = data.assistant?.pendingField || '';
-      assistantFieldValues = data.assistant?.fieldValues || {};
+      syncAssistantFieldValues(data.assistant?.fieldValues || {});
       if (data.location) {
         window.history.replaceState({}, '', data.location);
       }

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -3,138 +3,243 @@
 {% block title %}{{ app_name }} – Upload{% endblock %}
 
 {% block content %}
-<section class="upload-shell">
-  <div class="hero hero--compact">
-    <p class="eyebrow">MVP Upload Flow</p>
-    <h1>Bilder hochladen</h1>
-    <p>
-      Lade mehrere Bilder hoch, ergänze optionale Infos und starte damit einen neuen Draft.
-      Die Bilder werden lokal gespeichert und für den weiteren Workflow normalisiert.
-    </p>
+<section class="mx-auto flex max-w-6xl flex-col gap-8 py-8 lg:py-12">
+  <div class="grid gap-6 lg:grid-cols-[1.2fr_0.8fr] lg:items-start">
+    <section class="overflow-hidden rounded-[2rem] border border-emerald-100 bg-gradient-to-br from-emerald-50 via-white to-slate-50 shadow-soft">
+      <div class="border-b border-emerald-100 px-6 py-5 sm:px-8">
+        <p class="text-sm font-semibold uppercase tracking-[0.24em] text-emerald-700">Tailwind Assisted Selling</p>
+        <h1 class="mt-3 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Bilder hochladen</h1>
+        <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
+          Der Einstieg ist jetzt als chat-artiger Assistent gedacht. Du startest mit Bildern, ergänzt bei Bedarf kurze Hinweise,
+          und Open Inserto übernimmt danach die nächsten Rückfragen im Verlauf.
+        </p>
+      </div>
+
+      <div class="space-y-5 px-6 py-6 sm:px-8">
+        <div class="rounded-3xl bg-slate-950 px-4 py-5 text-white sm:px-5">
+          <div class="flex items-start gap-3">
+            <div class="mt-1 flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-500/20 text-lg ring-1 ring-white/10">✨</div>
+            <div class="min-w-0 flex-1">
+              <p class="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-200">Open Inserto Assistent</p>
+              <p class="mt-2 text-sm leading-6 text-slate-100">Lade deine Bilder hoch. Ich erkenne Produkt, Zustand und wichtige Merkmale, bestätige Unsicherheiten mit Buttons und frage nur dort nach, wo wirklich noch Infos fehlen.</p>
+            </div>
+          </div>
+        </div>
+
+        {% if errors %}
+          <div class="rounded-3xl border border-rose-200 bg-rose-50 px-5 py-4 text-rose-900 shadow-sm">
+            <strong class="block text-sm font-semibold">Upload fehlgeschlagen.</strong>
+            <ul class="mt-2 list-disc space-y-1 pl-5 text-sm">
+              {% for error in errors %}
+                <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+
+        <form class="space-y-5" method="post" action="/drafts/upload" enctype="multipart/form-data" data-assistant-upload-form>
+          <div class="space-y-4 rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Schritt 1</p>
+                <h2 class="mt-1 text-xl font-semibold text-slate-900">Mehrfach-Upload mit Vorschau</h2>
+                <p class="mt-2 text-sm text-slate-600">Unterstützt: JPG, PNG, WEBP, HEIC/HEIF, GIF, BMP und TIFF.</p>
+              </div>
+              <span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">Chat-Start mit Bildern</span>
+            </div>
+
+            <label class="group block rounded-[1.5rem] border border-dashed border-emerald-300 bg-emerald-50/70 p-6 transition hover:border-emerald-500 hover:bg-emerald-50" data-dropzone>
+              <input class="sr-only" type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
+              <div class="flex flex-col items-center justify-center gap-3 text-center">
+                <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm ring-1 ring-emerald-100">📸</div>
+                <div>
+                  <p class="text-base font-semibold text-slate-900">Dateien auswählen</p>
+                  <p class="mt-1 text-sm text-slate-600">Oder Bilder einfach hier hineinziehen</p>
+                </div>
+                <div class="flex flex-wrap justify-center gap-2 text-xs text-slate-500">
+                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 1 Bild</span>
+                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Maximal 20 Bilder</span>
+                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 500 px</span>
+                </div>
+              </div>
+            </label>
+
+            <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-preview-grid>
+              <p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>
+            </div>
+          </div>
+
+          <div class="space-y-4 rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Schritt 2</p>
+              <h2 class="mt-1 text-xl font-semibold text-slate-900">Optionaler Gesprächskontext</h2>
+              <p class="mt-2 text-sm text-slate-600">Diese Eingaben landen direkt im Assistenten-Flow, damit Rückfragen gezielter werden.</p>
+            </div>
+
+            <div class="grid gap-4">
+              <label class="block">
+                <span class="mb-2 block text-sm font-medium text-slate-800">Was soll ich über den Artikel schon wissen?</span>
+                <textarea class="min-h-28 w-full rounded-2xl border-slate-200 bg-slate-50 px-4 py-3 text-sm shadow-sm focus:border-emerald-500 focus:ring-emerald-500" name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Preisidee, Fundort ...">{{ form_values.notes or '' }}</textarea>
+              </label>
+
+              <div class="grid gap-4 md:grid-cols-2">
+                {% for field_name, field_label in extra_fields %}
+                  <label class="block">
+                    <span class="mb-2 block text-sm font-medium text-slate-800">{{ field_label }}</span>
+                    <input class="w-full rounded-2xl border-slate-200 bg-slate-50 px-4 py-3 text-sm shadow-sm focus:border-emerald-500 focus:ring-emerald-500" type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
+                  </label>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+
+          <div class="space-y-4 rounded-[1.75rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-soft">
+            <div class="flex items-start gap-3">
+              <div class="mt-1 flex h-11 w-11 items-center justify-center rounded-2xl bg-white/10 text-xl">🤖</div>
+              <div class="flex-1">
+                <p class="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-200">Schritt 3</p>
+                <h2 class="mt-1 text-xl font-semibold">Analyse starten</h2>
+                <p class="mt-2 text-sm leading-6 text-slate-300">Beim Absenden zeigen wir direkt eine moderne AI-Loading-Animation und wechseln danach in den Gesprächsverlauf des Drafts.</p>
+              </div>
+            </div>
+            <div class="flex flex-wrap gap-3 text-xs text-slate-300">
+              <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">Asynchroner Einstieg</span>
+              <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">Korrekturen im Chat</span>
+              <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">Kein Formular-Zwang</span>
+            </div>
+            <button class="inline-flex items-center justify-center rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300" type="submit" data-submit-button>Draft erstellen</button>
+          </div>
+        </form>
+      </div>
+    </section>
+
+    <aside class="space-y-6">
+      <section class="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">UX-Zielbild</p>
+        <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-900">Assistenten-Flow statt Formularwüste</h2>
+        <p class="mt-3 text-sm leading-6 text-slate-600">
+          Der Upload bleibt der Einstieg. Danach bestätigt der Assistent erkannte Angaben, stellt nur gezielte Rückfragen und hält den Nutzer im selben Gesprächskontext.
+        </p>
+        <div class="mt-5 space-y-3 rounded-[1.5rem] bg-slate-950 p-4 text-sm text-white shadow-soft">
+          <article class="max-w-[90%] rounded-2xl rounded-tl-sm bg-white/10 px-4 py-3">
+            <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-200">Open Inserto</strong>
+            <p class="mt-2 leading-6 text-slate-100">Ich analysiere jetzt deine Bilder und bereite den Verkaufsentwurf vor.</p>
+          </article>
+          <article class="max-w-[90%] rounded-2xl rounded-tl-sm bg-white/10 px-4 py-3">
+            <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-200">Open Inserto</strong>
+            <p class="mt-2 leading-6 text-slate-100">Ich habe ein iPhone erkannt. Farbe und Speicher prüfe ich gleich, fehlende Angaben frage ich nur bei Unsicherheit ab.</p>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <span class="rounded-full bg-emerald-400 px-3 py-1 text-xs font-semibold text-emerald-950">Super</span>
+              <span class="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white ring-1 ring-white/10">Ändern</span>
+            </div>
+          </article>
+          <article class="ml-auto max-w-[85%] rounded-2xl rounded-tr-sm bg-emerald-400 px-4 py-3 text-emerald-950">
+            <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-900">Du</strong>
+            <p class="mt-2 leading-6">256 GB, Zustand ist gut, Originalkabel ist dabei.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="rounded-[2rem] border border-emerald-100 bg-emerald-50 p-6 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-700">AI-Animationen</p>
+        <h2 class="mt-2 text-xl font-semibold text-slate-900">Sichtbare Analyse statt leerer Wartezeit</h2>
+        <div class="mt-4 rounded-[1.5rem] bg-slate-950 p-5 text-white shadow-soft">
+          <div class="flex items-center gap-3">
+            <div class="relative h-12 w-12">
+              <span class="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping"></span>
+              <span class="absolute inset-1 rounded-full bg-emerald-400/40 animate-pulse"></span>
+              <span class="absolute inset-[10px] rounded-full bg-emerald-400"></span>
+            </div>
+            <div>
+              <p class="text-sm font-semibold text-white">Analyse läuft</p>
+              <p class="mt-1 text-sm text-slate-300">Produktmerkmale, Zustand und eBay-relevante Hinweise werden vorbereitet.</p>
+            </div>
+          </div>
+          <div class="mt-4 flex items-center gap-2">
+            <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce [animation-delay:-0.3s]"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce [animation-delay:-0.15s]"></span>
+            <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce"></span>
+          </div>
+        </div>
+      </section>
+    </aside>
   </div>
 
-  {% if errors %}
-    <div class="alert alert--error">
-      <strong>Upload fehlgeschlagen.</strong>
-      <ul>
-        {% for error in errors %}
-          <li>{{ error }}</li>
-        {% endfor %}
-      </ul>
-    </div>
-  {% endif %}
-
-  <form class="upload-layout" method="post" action="/drafts/upload" enctype="multipart/form-data">
-    <section class="panel upload-dropzone" data-dropzone>
-      <div>
-        <p class="eyebrow">Bilder</p>
-        <h2>Mehrfach-Upload mit Vorschau</h2>
-        <p>Unterstützt: JPG, PNG, WEBP, HEIC/HEIF, GIF, BMP und TIFF.</p>
-      </div>
-
-      <label class="upload-picker">
-        <input type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
-        <span>Dateien auswählen</span>
-      </label>
-
-      <div class="upload-help">
-        <span>Mindestens 1 Bild</span>
-        <span>Maximal 20 Bilder</span>
-        <span>Mindestens 500 px auf der längsten Seite</span>
-      </div>
-
-      <div class="preview-grid" data-preview-grid>
-        <p class="empty-state">Noch keine Bilder ausgewählt.</p>
-      </div>
-    </section>
-
-    <section class="panel form-panel">
-      <div>
-        <p class="eyebrow">Zusatzinfos</p>
-        <h2>Kontext für den Draft</h2>
-      </div>
-
-      <label class="field field--full">
-        <span>Notizen</span>
-        <textarea name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Fundort, Preisidee ...">{{ form_values.notes or '' }}</textarea>
-      </label>
-
-      <div class="field-grid">
-        {% for field_name, field_label in extra_fields %}
-          <label class="field">
-            <span>{{ field_label }}</span>
-            <input type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
-          </label>
-        {% endfor %}
-      </div>
-
-      <button class="button button--primary" type="submit">Draft erstellen</button>
-    </section>
-  </form>
-  <section class="assistant-preview card">
-    <div class="section-head section-head--compact">
-      <div>
-        <p class="eyebrow">UX-Zielbild</p>
-        <h2>Assistenten-Flow statt Formularwüste</h2>
-      </div>
-      <span class="status-chip status-chip--muted">Nächste Phase</span>
-    </div>
-    <p class="section-copy">
-      Der Upload bleibt der Einstieg. Danach soll der Draft schrittweise in einen chat-artigen Assistenten-Flow übergehen,
-      der nur noch gezielte Rückfragen stellt und erkannte Angaben aktiv bestätigen lässt.
-    </p>
-    <div class="assistant-preview__chat" aria-label="Beispiel für den künftigen Assistenten-Flow">
-      <article class="assistant-bubble assistant-bubble--assistant">
-        <strong>Open Inserto</strong>
-        <p>Ich analysiere jetzt deine Bilder und bereite den Verkaufsentwurf vor.</p>
-      </article>
-      <article class="assistant-bubble assistant-bubble--assistant">
-        <strong>Open Inserto</strong>
-        <p>Ich habe ein iPhone erkannt. Farbe und Speicher prüfe ich gleich, fehlende Angaben frage ich nur bei Unsicherheit ab.</p>
-        <div class="assistant-choice-row">
-          <span class="assistant-choice">Super</span>
-          <span class="assistant-choice assistant-choice--secondary">Ändern</span>
+  <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-950/70 px-6 backdrop-blur-sm" data-analysis-overlay>
+    <div class="w-full max-w-md rounded-[2rem] border border-white/10 bg-slate-950 p-6 text-white shadow-soft">
+      <div class="flex items-center gap-4">
+        <div class="relative h-14 w-14 shrink-0">
+          <span class="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping"></span>
+          <span class="absolute inset-1 rounded-full bg-emerald-400/30 animate-pulse"></span>
+          <span class="absolute inset-[12px] rounded-full bg-emerald-400"></span>
         </div>
-      </article>
-      <article class="assistant-bubble assistant-bubble--user">
-        <strong>Du</strong>
-        <p>256 GB, Zustand ist gut, Originalkabel ist dabei.</p>
-      </article>
+        <div>
+          <p class="text-lg font-semibold">AI-Analyse läuft</p>
+          <p class="mt-1 text-sm text-slate-300">Bilder werden verarbeitet, Kernangaben erkannt und der Chat vorbereitet.</p>
+        </div>
+      </div>
+      <div class="mt-5 space-y-3">
+        <div class="h-3 overflow-hidden rounded-full bg-white/10">
+          <div class="h-full w-2/3 animate-pulse rounded-full bg-emerald-400"></div>
+        </div>
+        <div class="flex items-center gap-2 text-sm text-slate-300">
+          <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce [animation-delay:-0.3s]"></span>
+          <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce [animation-delay:-0.15s]"></span>
+          <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce"></span>
+          <span>Assistent baut den Gesprächsverlauf auf</span>
+        </div>
+      </div>
     </div>
-  </section>
+  </div>
 </section>
 
 <script>
   const input = document.querySelector('[data-image-input]');
   const previewGrid = document.querySelector('[data-preview-grid]');
   const dropzone = document.querySelector('[data-dropzone]');
+  const uploadForm = document.querySelector('[data-assistant-upload-form]');
+  const analysisOverlay = document.querySelector('[data-analysis-overlay]');
+  const submitButton = document.querySelector('[data-submit-button]');
 
   const renderPreviews = () => {
     const files = Array.from(input.files || []);
     if (!files.length) {
-      previewGrid.innerHTML = '<p class="empty-state">Noch keine Bilder ausgewählt.</p>';
+      previewGrid.innerHTML = '<p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>';
       return;
     }
 
     previewGrid.innerHTML = '';
     files.forEach((file, index) => {
       const item = document.createElement('article');
-      item.className = 'preview-card';
+      item.className = 'overflow-hidden rounded-[1.5rem] border border-slate-200 bg-slate-50 shadow-sm';
 
+      const header = document.createElement('div');
+      header.className = 'flex items-start justify-between gap-3 px-4 pt-4';
+
+      const titleWrap = document.createElement('div');
       const title = document.createElement('strong');
+      title.className = 'block text-sm font-semibold text-slate-900';
       title.textContent = `${index + 1}. ${file.name}`;
-      item.appendChild(title);
+      titleWrap.appendChild(title);
 
       const meta = document.createElement('span');
-      meta.className = 'preview-meta';
+      meta.className = 'mt-1 block text-xs text-slate-500';
       meta.textContent = `${Math.round(file.size / 1024)} KB · ${file.type || 'unbekannt'}`;
-      item.appendChild(meta);
+      titleWrap.appendChild(meta);
+      header.appendChild(titleWrap);
+
+      const badge = document.createElement('span');
+      badge.className = 'rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-medium text-emerald-800';
+      badge.textContent = 'Bereit';
+      header.appendChild(badge);
+      item.appendChild(header);
 
       if (file.type.startsWith('image/')) {
         const img = document.createElement('img');
         img.alt = file.name;
         img.loading = 'lazy';
         img.src = URL.createObjectURL(file);
+        img.className = 'mt-4 h-48 w-full object-cover';
         item.appendChild(img);
       }
 
@@ -147,14 +252,14 @@
   ['dragenter', 'dragover'].forEach((eventName) => {
     dropzone?.addEventListener(eventName, (event) => {
       event.preventDefault();
-      dropzone.classList.add('is-dragover');
+      dropzone.classList.add('border-emerald-500', 'bg-emerald-100');
     });
   });
 
   ['dragleave', 'drop'].forEach((eventName) => {
     dropzone?.addEventListener(eventName, (event) => {
       event.preventDefault();
-      dropzone.classList.remove('is-dragover');
+      dropzone.classList.remove('border-emerald-500', 'bg-emerald-100');
     });
   });
 
@@ -163,6 +268,15 @@
     if (!files?.length) return;
     input.files = files;
     renderPreviews();
+  });
+
+  uploadForm?.addEventListener('submit', () => {
+    analysisOverlay?.classList.remove('hidden');
+    analysisOverlay?.classList.add('flex');
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.textContent = 'Analyse läuft ...';
+    }
   });
 </script>
 {% endblock %}

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -73,7 +73,7 @@
       <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce [animation-delay:-0.15s]"></span>
       <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce"></span>
     </div>
-    <p class="mt-3 hidden text-sm leading-6 text-slate-100" data-chat-text></p>
+    <p class="mt-3 hidden whitespace-pre-line text-sm leading-6 text-slate-100" data-chat-text></p>
   </article>
 </template>
 
@@ -144,6 +144,22 @@
   let currentDraftId = null;
   let currentDraftLocation = '';
   let assistantPendingField = '';
+  let assistantFieldValues = {};
+
+  const messageSignature = (message) => JSON.stringify({
+    role: message.role,
+    text: message.text,
+    tone: message.tone || '',
+    actions: Array.isArray(message.actions)
+      ? message.actions.map((action) => ({
+          kind: action.kind,
+          label: action.label,
+          field: action.field || '',
+          value: action.value || '',
+          href: action.href || '',
+        }))
+      : [],
+  });
 
   const escapeHtml = (value) => String(value || '')
     .replace(/&/g, '&amp;')
@@ -153,11 +169,12 @@
     .replace(/'/g, '&#039;');
 
   const assistantFieldCurrentValue = (field) => {
+    if (assistantFieldValues[field]) return assistantFieldValues[field];
     if (field === 'title') return uploadForm?.querySelector('[data-extra-input="product_name"]')?.value || '';
     if (field === 'condition') return uploadForm?.querySelector('[data-extra-input="condition"]')?.value || '';
     if (field === 'included_items') return uploadForm?.querySelector('[data-extra-input="accessories"]')?.value || '';
     if (field === 'description_html') return notesInput?.value || '';
-    if (field === 'category_suggestion') return '';
+    if (field === 'category_suggestion') return assistantFieldValues.category_suggestion_id || assistantFieldValues.category_suggestion || '';
     return '';
   };
 
@@ -221,21 +238,38 @@
     if (!response.ok) return;
     const data = await response.json();
     assistantPendingField = data.pendingField || '';
+    assistantFieldValues = data.fieldValues || assistantFieldValues;
     await renderAssistantMessages(data.messages || []);
   };
 
   const renderAssistantMessages = async (messages) => {
-    chatThread?.querySelectorAll('[data-assistant-actions]').forEach((node) => node.remove());
+    const renderedNodes = Array.from(chatThread?.querySelectorAll('[data-chat-node]') || []);
+    const renderedSignatures = renderedNodes.map((node) => node.dataset.messageSignature || '');
+    const nextSignatures = messages.map((message) => messageSignature(message));
 
-    for (const message of messages) {
+    let prefixLength = 0;
+    while (
+      prefixLength < renderedSignatures.length &&
+      prefixLength < nextSignatures.length &&
+      renderedSignatures[prefixLength] === nextSignatures[prefixLength]
+    ) {
+      prefixLength += 1;
+    }
+
+    renderedNodes.forEach((node, index) => {
+      if (index >= prefixLength) node.remove();
+    });
+
+    for (const message of messages.slice(prefixLength)) {
+      let node;
       if (message.role === 'user') {
-        appendUserMessage(`<p>${escapeHtml(message.text)}</p>`);
-        continue;
+        node = appendUserMessage(`<p>${escapeHtml(message.text)}</p>`);
+      } else {
+        node = await appendAssistantMessage(message.text, 650);
       }
-
-      await appendAssistantMessage(message.text, 650);
-      const lastNode = chatThread?.lastElementChild;
-      if (!lastNode || !Array.isArray(message.actions) || !message.actions.length) continue;
+      node.dataset.chatNode = 'true';
+      node.dataset.messageSignature = messageSignature(message);
+      if (message.role === 'user' || !Array.isArray(message.actions) || !message.actions.length) continue;
 
       const row = document.createElement('div');
       row.className = 'mt-4 flex flex-wrap gap-2';
@@ -259,7 +293,7 @@
         button.textContent = action.label;
         row.appendChild(button);
       });
-      lastNode.appendChild(row);
+      node.appendChild(row);
     }
   };
 
@@ -398,9 +432,14 @@
       currentDraftId = data.draftId;
       currentDraftLocation = data.location || `/drafts/${data.draftId}`;
       assistantPendingField = data.assistant?.pendingField || '';
+      assistantFieldValues = data.assistant?.fieldValues || {};
       if (data.location) {
         window.history.replaceState({}, '', data.location);
       }
+
+      node.remove();
+      document.querySelector('[data-inline-assistant-composer]')?.remove();
+      document.querySelector('[data-dropzone]')?.closest('article')?.remove();
 
       analysisOverlay?.classList.add('hidden');
       analysisOverlay?.classList.remove('flex');

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -5,92 +5,29 @@
 {% block content %}
 <section class="mx-auto flex max-w-4xl flex-col py-0 sm:py-8">
   <div class="overflow-hidden bg-transparent sm:rounded-[2rem] sm:border sm:border-slate-200 sm:bg-white sm:shadow-soft">
-    <div class="space-y-4 bg-gradient-to-b from-slate-100 via-slate-50 to-white px-0 py-4 sm:px-6 sm:py-6">
-      <div class="space-y-4" data-chat-sequence>
-        <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-4 text-white shadow-soft opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
-          <div class="flex items-center gap-3">
-            <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg">✨</div>
-            <div>
-              <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
-              <p class="text-xs text-slate-400">schreibt gerade</p>
-            </div>
-          </div>
-          <div class="mt-3 flex items-center gap-2 text-emerald-200" data-typing-indicator>
-            <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce [animation-delay:-0.3s]"></span>
-            <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce [animation-delay:-0.15s]"></span>
-            <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce"></span>
-          </div>
-          <p class="mt-3 hidden text-sm leading-6 text-slate-100" data-chat-text>Hi, lade zuerst deine Bilder hoch. Ich speichere sie erst einmal intern und gehe danach mit dir Schritt für Schritt durch die nächsten Infos.</p>
-        </article>
-
-        {% if errors %}
-          <div class="max-w-[92%] rounded-[1.5rem] rounded-tl-sm border border-rose-200 bg-rose-50 px-5 py-4 text-rose-900 shadow-sm">
-            <strong class="block text-sm font-semibold">Upload fehlgeschlagen.</strong>
-            <ul class="mt-2 list-disc space-y-1 pl-5 text-sm">
-              {% for error in errors %}
-                <li>{{ error }}</li>
-              {% endfor %}
-            </ul>
-          </div>
-        {% endif %}
-
-        <form class="space-y-4" method="post" action="/drafts/upload" enctype="multipart/form-data" data-assistant-upload-form>
-          <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm border border-slate-200 bg-white px-5 py-5 shadow-sm opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
-            <strong class="block text-sm font-semibold text-slate-900">Open Inserto</strong>
-            <p class="mt-2 text-sm leading-6 text-slate-600">Schick mir jetzt die Fotos. Wichtig: Die Bilder werden hier erst einmal nur hochgeladen, noch nicht direkt analysiert.</p>
-
-            <label class="group mt-4 block rounded-[1.5rem] border border-dashed border-emerald-300 bg-emerald-50/70 p-6 transition hover:border-emerald-500 hover:bg-emerald-50" data-dropzone>
-              <input class="sr-only" type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
-              <div class="flex flex-col items-center justify-center gap-3 text-center">
-                <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm ring-1 ring-emerald-100">📸</div>
-                <div>
-                  <p class="text-base font-semibold text-slate-900">Bilder hochladen</p>
-                  <p class="mt-1 text-sm text-slate-600">Oder Bilder einfach hier hineinziehen</p>
-                </div>
-                <div class="flex flex-wrap justify-center gap-2 text-xs text-slate-500">
-                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 1 Bild</span>
-                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Maximal 20 Bilder</span>
-                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 500 px</span>
-                </div>
-              </div>
-            </label>
-
-            <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-preview-grid>
-              <p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>
-            </div>
-          </article>
-
-          <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-5 text-white shadow-soft opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
-            <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
-            <p class="mt-2 text-sm leading-6 text-slate-100">Wenn du magst, gib mir direkt noch ein paar Hinweise mit. Das spart später Rückfragen.</p>
-          </article>
-
-          <article class="ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-5 text-emerald-950 shadow-sm opacity-0 transition duration-500 data-[visible=true]:opacity-100" data-chat-step>
-            <strong class="block text-sm font-semibold">Du</strong>
-
-            <div class="mt-4 grid gap-4">
-              <label class="block">
-                <span class="mb-2 block text-sm font-medium">Was soll ich über den Artikel schon wissen?</span>
-                <textarea class="min-h-28 w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Preisidee, Fundort ...">{{ form_values.notes or '' }}</textarea>
-              </label>
-
-              <div class="grid gap-4 md:grid-cols-2">
-                {% for field_name, field_label in extra_fields %}
-                  <label class="block">
-                    <span class="mb-2 block text-sm font-medium">{{ field_label }}</span>
-                    <input class="w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
-                  </label>
-                {% endfor %}
-              </div>
-
-              <div class="flex flex-wrap items-center justify-end gap-3">
-                <span class="text-sm text-emerald-900/80">Antwort wird zusammen mit deinen Bildern gesendet.</span>
-                <button class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/20 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-950/30" type="submit" data-submit-button>Bilder senden</button>
-              </div>
-            </div>
-          </article>
-        </form>
+    <div class="bg-gradient-to-b from-slate-100 via-slate-50 to-white px-0 py-4 sm:px-6 sm:py-6">
+      <div class="flex min-h-[70vh] flex-col rounded-none bg-transparent sm:min-h-[42rem] sm:rounded-[1.75rem] sm:bg-white/70 sm:ring-1 sm:ring-slate-200/70">
+        <div class="flex-1 space-y-4 overflow-y-auto px-0 pb-6 pt-2 sm:px-6" data-chat-thread></div>
       </div>
+
+      {% if errors %}
+        <div class="mt-4 rounded-[1.5rem] border border-rose-200 bg-rose-50 px-5 py-4 text-rose-900 shadow-sm">
+          <strong class="block text-sm font-semibold">Upload fehlgeschlagen.</strong>
+          <ul class="mt-2 list-disc space-y-1 pl-5 text-sm">
+            {% for error in errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      <form class="hidden" method="post" action="/drafts/upload" enctype="multipart/form-data" data-assistant-upload-form>
+        <input type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
+        <textarea name="notes" data-notes-input>{{ form_values.notes or '' }}</textarea>
+        {% for field_name, field_label in extra_fields %}
+          <input type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" data-extra-input="{{ field_name }}">
+        {% endfor %}
+      </form>
     </div>
   </div>
 
@@ -122,40 +59,148 @@
   </div>
 </section>
 
-<script>
-  const input = document.querySelector('[data-image-input]');
-  const previewGrid = document.querySelector('[data-preview-grid]');
-  const dropzone = document.querySelector('[data-dropzone]');
-  const uploadForm = document.querySelector('[data-assistant-upload-form]');
-  const analysisOverlay = document.querySelector('[data-analysis-overlay]');
-  const submitButton = document.querySelector('[data-submit-button]');
+<template id="assistant-message-template">
+  <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-4 text-white shadow-soft opacity-0 translate-y-4 transition duration-500">
+    <div class="flex items-center gap-3">
+      <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg">✨</div>
+      <div>
+        <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
+        <p class="text-xs text-slate-400" data-status>schreibt gerade</p>
+      </div>
+    </div>
+    <div class="mt-3 flex items-center gap-2 text-emerald-200" data-typing-indicator>
+      <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce [animation-delay:-0.3s]"></span>
+      <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce [animation-delay:-0.15s]"></span>
+      <span class="h-2.5 w-2.5 rounded-full bg-current animate-bounce"></span>
+    </div>
+    <p class="mt-3 hidden text-sm leading-6 text-slate-100" data-chat-text></p>
+  </article>
+</template>
 
-  const revealChat = () => {
-    const steps = document.querySelectorAll('[data-chat-step]');
-    steps.forEach((step, index) => {
-      window.setTimeout(() => {
-        step.dataset.visible = 'true';
-        const typingIndicator = step.querySelector('[data-typing-indicator]');
-        const text = step.querySelector('[data-chat-text]');
-        if (typingIndicator && text) {
-          window.setTimeout(() => {
-            typingIndicator.classList.add('hidden');
-            text.classList.remove('hidden');
-          }, 900);
-        }
-      }, index * 260);
+<template id="user-message-template">
+  <article class="ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-4 text-emerald-950 shadow-sm opacity-0 translate-y-4 transition duration-500">
+    <strong class="block text-sm font-semibold">Du</strong>
+    <div class="mt-3 text-sm leading-6" data-user-content></div>
+  </article>
+</template>
+
+<template id="upload-card-template">
+  <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm border border-slate-200 bg-white px-5 py-5 shadow-sm opacity-0 translate-y-4 transition duration-500">
+    <strong class="block text-sm font-semibold text-slate-900">Open Inserto</strong>
+    <p class="mt-2 text-sm leading-6 text-slate-600">Schick mir jetzt die Fotos. Wichtig: Die Bilder werden hier erst einmal nur hochgeladen, noch nicht direkt analysiert.</p>
+
+    <label class="group mt-4 block cursor-pointer rounded-[1.5rem] border border-dashed border-emerald-300 bg-emerald-50/70 p-6 transition hover:border-emerald-500 hover:bg-emerald-50" data-dropzone>
+      <input class="sr-only" type="file" accept="image/*,.heic,.heif" multiple data-virtual-image-input>
+      <div class="flex flex-col items-center justify-center gap-3 text-center">
+        <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm ring-1 ring-emerald-100">📸</div>
+        <div>
+          <p class="text-base font-semibold text-slate-900">Bilder hochladen</p>
+          <p class="mt-1 text-sm text-slate-600">Oder Bilder einfach hier hineinziehen</p>
+        </div>
+        <div class="flex flex-wrap justify-center gap-2 text-xs text-slate-500">
+          <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 1 Bild</span>
+          <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Maximal 20 Bilder</span>
+          <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 500 px</span>
+        </div>
+      </div>
+    </label>
+
+    <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-preview-grid>
+      <p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>
+    </div>
+  </article>
+</template>
+
+<template id="notes-composer-template">
+  <article class="ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-5 text-emerald-950 shadow-sm opacity-0 translate-y-4 transition duration-500">
+    <strong class="block text-sm font-semibold">Du</strong>
+
+    <div class="mt-4 grid gap-4">
+      <label class="block">
+        <span class="mb-2 block text-sm font-medium">Was soll ich über den Artikel schon wissen?</span>
+        <textarea class="min-h-28 w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" rows="5" placeholder="Zustand, Auffälligkeiten, Preisidee, Fundort ..." data-notes-field></textarea>
+      </label>
+
+      <div class="grid gap-4 md:grid-cols-2" data-extra-fields></div>
+
+      <div class="flex flex-wrap items-center justify-end gap-3">
+        <span class="text-sm text-emerald-900/80">Antwort wird zusammen mit deinen Bildern gesendet.</span>
+        <button class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/20 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-950/30" type="button" data-submit-button>Bilder senden</button>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script>
+  const chatThread = document.querySelector('[data-chat-thread]');
+  const uploadForm = document.querySelector('[data-assistant-upload-form]');
+  const realInput = uploadForm?.querySelector('[data-image-input]');
+  const notesInput = uploadForm?.querySelector('[data-notes-input]');
+  const analysisOverlay = document.querySelector('[data-analysis-overlay]');
+  const extraFieldMeta = {{ extra_fields | tojson }};
+
+  let uploadStepMounted = false;
+  let notesStepMounted = false;
+
+  const syncFileInput = (files) => {
+    if (!realInput) return;
+    const transfer = new DataTransfer();
+    Array.from(files || []).forEach((file) => transfer.items.add(file));
+    realInput.files = transfer.files;
+  };
+
+  const scrollToBottom = (behavior = 'smooth') => {
+    window.requestAnimationFrame(() => {
+      chatThread?.lastElementChild?.scrollIntoView({ behavior, block: 'end' });
     });
   };
 
-  const renderPreviews = () => {
-    const files = Array.from(input.files || []);
-    if (!files.length) {
+  const revealNode = (node) => {
+    window.requestAnimationFrame(() => {
+      node.classList.remove('opacity-0', 'translate-y-4');
+      scrollToBottom();
+    });
+  };
+
+  const appendAssistantMessage = (text, delay = 900) => new Promise((resolve) => {
+    const template = document.getElementById('assistant-message-template');
+    const node = template.content.firstElementChild.cloneNode(true);
+    const status = node.querySelector('[data-status]');
+    const typing = node.querySelector('[data-typing-indicator]');
+    const body = node.querySelector('[data-chat-text]');
+
+    chatThread.appendChild(node);
+    revealNode(node);
+    scrollToBottom('auto');
+
+    window.setTimeout(() => {
+      typing.classList.add('hidden');
+      status.textContent = 'soeben gesendet';
+      body.textContent = text;
+      body.classList.remove('hidden');
+      scrollToBottom();
+      resolve(node);
+    }, delay);
+  });
+
+  const appendUserMessage = (html) => {
+    const template = document.getElementById('user-message-template');
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.querySelector('[data-user-content]').innerHTML = html;
+    chatThread.appendChild(node);
+    revealNode(node);
+    return node;
+  };
+
+  const renderPreviews = (files, previewGrid) => {
+    const allFiles = Array.from(files || []);
+    if (!allFiles.length) {
       previewGrid.innerHTML = '<p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>';
       return;
     }
 
     previewGrid.innerHTML = '';
-    files.forEach((file, index) => {
+    allFiles.forEach((file, index) => {
       const item = document.createElement('article');
       item.className = 'overflow-hidden rounded-[1.5rem] border border-slate-200 bg-slate-50 shadow-sm';
 
@@ -176,11 +221,11 @@
 
       const badge = document.createElement('span');
       badge.className = 'rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-medium text-emerald-800';
-      badge.textContent = 'Hochgeladen';
+      badge.textContent = 'Ausgewählt';
       header.appendChild(badge);
       item.appendChild(header);
 
-      if (file.type.startsWith('image/')) {
+      if ((file.type || '').startsWith('image/')) {
         const img = document.createElement('img');
         img.alt = file.name;
         img.loading = 'lazy';
@@ -193,37 +238,106 @@
     });
   };
 
-  revealChat();
-  input?.addEventListener('change', renderPreviews);
+  const mountNotesComposer = async () => {
+    if (notesStepMounted) return;
+    notesStepMounted = true;
 
-  ['dragenter', 'dragover'].forEach((eventName) => {
-    dropzone?.addEventListener(eventName, (event) => {
-      event.preventDefault();
-      dropzone.classList.add('border-emerald-500', 'bg-emerald-100');
+    await appendAssistantMessage('Perfekt, die Bilder sind vorgemerkt. Wenn du magst, gib mir direkt noch ein paar Hinweise mit. Das spart später Rückfragen.');
+
+    const template = document.getElementById('notes-composer-template');
+    const node = template.content.firstElementChild.cloneNode(true);
+    const notesField = node.querySelector('[data-notes-field]');
+    const extraFieldsWrap = node.querySelector('[data-extra-fields]');
+    const submitButton = node.querySelector('[data-submit-button]');
+
+    extraFieldMeta.forEach(([fieldName, fieldLabel]) => {
+      const label = document.createElement('label');
+      label.className = 'block';
+      label.innerHTML = `
+        <span class="mb-2 block text-sm font-medium">${fieldLabel}</span>
+        <input class="w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" type="text" placeholder="${fieldLabel}">
+      `;
+      const field = label.querySelector('input');
+      const backing = uploadForm?.querySelector(`[data-extra-input="${fieldName}"]`);
+      field.value = backing?.value || '';
+      field.addEventListener('input', () => {
+        if (backing) backing.value = field.value;
+      });
+      extraFieldsWrap.appendChild(label);
     });
-  });
 
-  ['dragleave', 'drop'].forEach((eventName) => {
-    dropzone?.addEventListener(eventName, (event) => {
-      event.preventDefault();
-      dropzone.classList.remove('border-emerald-500', 'bg-emerald-100');
+    notesField.value = notesInput?.value || '';
+    notesField.addEventListener('input', () => {
+      if (notesInput) notesInput.value = notesField.value;
     });
-  });
 
-  dropzone?.addEventListener('drop', (event) => {
-    const files = event.dataTransfer?.files;
-    if (!files?.length) return;
-    input.files = files;
-    renderPreviews();
-  });
-
-  uploadForm?.addEventListener('submit', () => {
-    analysisOverlay?.classList.remove('hidden');
-    analysisOverlay?.classList.add('flex');
-    if (submitButton) {
+    submitButton.addEventListener('click', () => {
+      analysisOverlay?.classList.remove('hidden');
+      analysisOverlay?.classList.add('flex');
       submitButton.disabled = true;
       submitButton.textContent = 'Analyse läuft ...';
-    }
-  });
+      uploadForm?.requestSubmit();
+    });
+
+    chatThread.appendChild(node);
+    revealNode(node);
+  };
+
+  const mountUploadCard = () => {
+    if (uploadStepMounted) return;
+    uploadStepMounted = true;
+
+    const template = document.getElementById('upload-card-template');
+    const node = template.content.firstElementChild.cloneNode(true);
+    const virtualInput = node.querySelector('[data-virtual-image-input]');
+    const previewGrid = node.querySelector('[data-preview-grid]');
+    const dropzone = node.querySelector('[data-dropzone]');
+
+    const handleFiles = async (files) => {
+      if (!files?.length) return;
+      syncFileInput(files);
+      renderPreviews(files, previewGrid);
+      appendUserMessage(`<p>${files.length} Bild${files.length === 1 ? '' : 'er'} ausgewählt und zum Upload bereit.</p>`);
+      await mountNotesComposer();
+    };
+
+    virtualInput?.addEventListener('change', (event) => {
+      const files = event.target.files;
+      handleFiles(files);
+    });
+
+    ['dragenter', 'dragover'].forEach((eventName) => {
+      dropzone?.addEventListener(eventName, (event) => {
+        event.preventDefault();
+        dropzone.classList.add('border-emerald-500', 'bg-emerald-100');
+      });
+    });
+
+    ['dragleave', 'drop'].forEach((eventName) => {
+      dropzone?.addEventListener(eventName, (event) => {
+        event.preventDefault();
+        dropzone.classList.remove('border-emerald-500', 'bg-emerald-100');
+      });
+    });
+
+    dropzone?.addEventListener('drop', (event) => {
+      const files = event.dataTransfer?.files;
+      if (!files?.length || !virtualInput) return;
+      virtualInput.files = files;
+      handleFiles(files);
+    });
+
+    chatThread.appendChild(node);
+    revealNode(node);
+  };
+
+  const boot = async () => {
+    await appendAssistantMessage('Hi, lade zuerst deine Bilder hoch. Ich speichere sie erst einmal intern und gehe danach mit dir Schritt für Schritt durch die nächsten Infos.');
+    window.setTimeout(() => {
+      mountUploadCard();
+    }, 240);
+  };
+
+  boot();
 </script>
 {% endblock %}

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -71,6 +71,37 @@
       <button class="button button--primary" type="submit">Draft erstellen</button>
     </section>
   </form>
+  <section class="assistant-preview card">
+    <div class="section-head section-head--compact">
+      <div>
+        <p class="eyebrow">UX-Zielbild</p>
+        <h2>Assistenten-Flow statt Formularwüste</h2>
+      </div>
+      <span class="status-chip status-chip--muted">Nächste Phase</span>
+    </div>
+    <p class="section-copy">
+      Der Upload bleibt der Einstieg. Danach soll der Draft schrittweise in einen chat-artigen Assistenten-Flow übergehen,
+      der nur noch gezielte Rückfragen stellt und erkannte Angaben aktiv bestätigen lässt.
+    </p>
+    <div class="assistant-preview__chat" aria-label="Beispiel für den künftigen Assistenten-Flow">
+      <article class="assistant-bubble assistant-bubble--assistant">
+        <strong>Open Inserto</strong>
+        <p>Ich analysiere jetzt deine Bilder und bereite den Verkaufsentwurf vor.</p>
+      </article>
+      <article class="assistant-bubble assistant-bubble--assistant">
+        <strong>Open Inserto</strong>
+        <p>Ich habe ein iPhone erkannt. Farbe und Speicher prüfe ich gleich, fehlende Angaben frage ich nur bei Unsicherheit ab.</p>
+        <div class="assistant-choice-row">
+          <span class="assistant-choice">Super</span>
+          <span class="assistant-choice assistant-choice--secondary">Ändern</span>
+        </div>
+      </article>
+      <article class="assistant-bubble assistant-bubble--user">
+        <strong>Du</strong>
+        <p>256 GB, Zustand ist gut, Originalkabel ist dabei.</p>
+      </article>
+    </div>
+  </section>
 </section>
 
 <script>

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -141,6 +141,8 @@
 
   let uploadStepMounted = false;
   let notesStepMounted = false;
+  let currentDraftId = null;
+  let assistantPendingField = '';
 
   const syncFileInput = (files) => {
     if (!realInput) return;
@@ -190,6 +192,75 @@
     chatThread.appendChild(node);
     revealNode(node);
     return node;
+  };
+
+  const sendAssistantAction = async (payload) => {
+    if (!currentDraftId) return;
+    const response = await fetch(`/drafts/${currentDraftId}/assistant/message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) return;
+    const data = await response.json();
+    assistantPendingField = data.pendingField || '';
+    await renderAssistantMessages(data.messages || []);
+  };
+
+  const renderAssistantMessages = async (messages) => {
+    for (const message of messages) {
+      if (message.role === 'user') {
+        appendUserMessage(`<p>${message.text}</p>`);
+        continue;
+      }
+
+      await appendAssistantMessage(message.text, 650);
+      const lastNode = chatThread?.lastElementChild;
+      if (!lastNode || !Array.isArray(message.actions) || !message.actions.length) continue;
+
+      const row = document.createElement('div');
+      row.className = 'mt-4 flex flex-wrap gap-2';
+      message.actions.forEach((action) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = `inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition ${action.kind === 'edit' ? 'bg-white text-slate-950 hover:bg-slate-100' : 'bg-emerald-400 text-emerald-950 hover:bg-emerald-300'}`;
+        button.dataset.assistantAction = action.kind;
+        button.dataset.assistantField = action.field;
+        if (action.value) button.dataset.assistantValue = action.value;
+        button.textContent = action.label;
+        row.appendChild(button);
+      });
+      lastNode.appendChild(row);
+    }
+  };
+
+  const showAssistantComposer = (field) => {
+    const existing = document.querySelector('[data-inline-assistant-composer]');
+    existing?.remove();
+
+    const wrapper = document.createElement('article');
+    wrapper.className = 'ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-5 text-emerald-950 shadow-sm opacity-0 translate-y-4 transition duration-500';
+    wrapper.dataset.inlineAssistantComposer = 'true';
+    wrapper.innerHTML = `
+      <strong class="block text-sm font-semibold">Du</strong>
+      <div class="mt-4 grid gap-3">
+        <textarea class="min-h-24 w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm" placeholder="${field === 'category_suggestion' ? 'Kategorie oder Suchbegriff eingeben' : 'Antwort hier eingeben'}"></textarea>
+        <div class="flex justify-end gap-3">
+          <button class="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white" type="button">Senden</button>
+        </div>
+      </div>
+    `;
+    const textarea = wrapper.querySelector('textarea');
+    const button = wrapper.querySelector('button');
+    button.addEventListener('click', async () => {
+      if (!textarea.value.trim()) return;
+      const value = textarea.value.trim();
+      wrapper.remove();
+      await sendAssistantAction({ action: 'answer', field, value });
+    });
+    chatThread.appendChild(wrapper);
+    revealNode(wrapper);
+    textarea?.focus();
   };
 
   const renderPreviews = (files, previewGrid) => {
@@ -271,12 +342,41 @@
       if (notesInput) notesInput.value = notesField.value;
     });
 
-    submitButton.addEventListener('click', () => {
+    submitButton.addEventListener('click', async () => {
+      const formData = new FormData(uploadForm);
       analysisOverlay?.classList.remove('hidden');
       analysisOverlay?.classList.add('flex');
       submitButton.disabled = true;
       submitButton.textContent = 'Analyse läuft ...';
-      uploadForm?.requestSubmit();
+
+      const response = await fetch('/drafts/upload', {
+        method: 'POST',
+        body: formData,
+        headers: { Accept: 'application/json' },
+      });
+
+      if (!response.ok) {
+        analysisOverlay?.classList.add('hidden');
+        analysisOverlay?.classList.remove('flex');
+        submitButton.disabled = false;
+        submitButton.textContent = 'Bilder senden';
+        await appendAssistantMessage('Der Upload hat gerade nicht geklappt. Prüfe bitte die Bilder und versuche es nochmal.');
+        return;
+      }
+
+      const data = await response.json();
+      currentDraftId = data.draftId;
+      assistantPendingField = data.assistant?.pendingField || '';
+      if (data.location) {
+        window.history.replaceState({}, '', data.location);
+      }
+
+      analysisOverlay?.classList.add('hidden');
+      analysisOverlay?.classList.remove('flex');
+      await appendAssistantMessage('Alles klar, die Bilder sind jetzt hochgeladen und ich bleibe mit dir im selben Chat-Fenster.');
+      if (data.assistant?.messages?.length) {
+        await renderAssistantMessages(data.assistant.messages);
+      }
     });
 
     chatThread.appendChild(node);
@@ -337,6 +437,20 @@
       mountUploadCard();
     }, 240);
   };
+
+  document.body.addEventListener('click', async (event) => {
+    const button = event.target.closest('[data-assistant-action]');
+    if (!button) return;
+    const action = button.dataset.assistantAction;
+    const field = button.dataset.assistantField;
+    const value = button.dataset.assistantValue || '';
+    if (action === 'edit') {
+      assistantPendingField = field;
+      showAssistantComposer(field);
+      return;
+    }
+    await sendAssistantAction({ action, field, value });
+  });
 
   boot();
 </script>

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -3,166 +3,94 @@
 {% block title %}{{ app_name }} – Upload{% endblock %}
 
 {% block content %}
-<section class="mx-auto flex max-w-6xl flex-col gap-8 py-8 lg:py-12">
-  <div class="grid gap-6 lg:grid-cols-[1.2fr_0.8fr] lg:items-start">
-    <section class="overflow-hidden rounded-[2rem] border border-emerald-100 bg-gradient-to-br from-emerald-50 via-white to-slate-50 shadow-soft">
-      <div class="border-b border-emerald-100 px-6 py-5 sm:px-8">
-        <p class="text-sm font-semibold uppercase tracking-[0.24em] text-emerald-700">Tailwind Assisted Selling</p>
-        <h1 class="mt-3 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Bilder hochladen</h1>
-        <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
-          Der Einstieg ist jetzt als chat-artiger Assistent gedacht. Du startest mit Bildern, ergänzt bei Bedarf kurze Hinweise,
-          und Open Inserto übernimmt danach die nächsten Rückfragen im Verlauf.
-        </p>
-      </div>
+<section class="mx-auto flex max-w-5xl flex-col gap-6 py-6 sm:py-10">
+  <div class="overflow-hidden rounded-[2rem] border border-slate-200 bg-white shadow-soft">
+    <div class="border-b border-slate-200 bg-slate-950 px-5 py-5 text-white sm:px-8">
+      <h1 class="text-3xl font-semibold tracking-tight sm:text-4xl">Bilder hochladen</h1>
+      <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">
+        Starte einfach mit Fotos. Danach fragt dich der Assistent nur noch das, was für ein gutes Angebot wirklich noch fehlt.
+      </p>
+    </div>
 
-      <div class="space-y-5 px-6 py-6 sm:px-8">
-        <div class="rounded-3xl bg-slate-950 px-4 py-5 text-white sm:px-5">
-          <div class="flex items-start gap-3">
-            <div class="mt-1 flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-500/20 text-lg ring-1 ring-white/10">✨</div>
-            <div class="min-w-0 flex-1">
-              <p class="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-200">Open Inserto Assistent</p>
-              <p class="mt-2 text-sm leading-6 text-slate-100">Lade deine Bilder hoch. Ich erkenne Produkt, Zustand und wichtige Merkmale, bestätige Unsicherheiten mit Buttons und frage nur dort nach, wo wirklich noch Infos fehlen.</p>
-            </div>
-          </div>
+    <div class="space-y-5 bg-gradient-to-b from-slate-100/70 to-white px-4 py-5 sm:px-6 sm:py-6">
+      <article class="max-w-[90%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-4 text-white shadow-soft">
+        <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-200">Open Inserto</strong>
+        <p class="mt-2 text-sm leading-6 text-slate-100">Hi, lade zuerst deine Bilder hoch. Ich erkenne Produkt, Zustand und wichtige Merkmale und melde mich danach mit passenden Rückfragen oder Auswahlbuttons.</p>
+      </article>
+
+      {% if errors %}
+        <div class="max-w-[90%] rounded-[1.5rem] rounded-tl-sm border border-rose-200 bg-rose-50 px-5 py-4 text-rose-900 shadow-sm">
+          <strong class="block text-sm font-semibold">Upload fehlgeschlagen.</strong>
+          <ul class="mt-2 list-disc space-y-1 pl-5 text-sm">
+            {% for error in errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
         </div>
+      {% endif %}
 
-        {% if errors %}
-          <div class="rounded-3xl border border-rose-200 bg-rose-50 px-5 py-4 text-rose-900 shadow-sm">
-            <strong class="block text-sm font-semibold">Upload fehlgeschlagen.</strong>
-            <ul class="mt-2 list-disc space-y-1 pl-5 text-sm">
-              {% for error in errors %}
-                <li>{{ error }}</li>
-              {% endfor %}
-            </ul>
-          </div>
-        {% endif %}
+      <form class="space-y-5" method="post" action="/drafts/upload" enctype="multipart/form-data" data-assistant-upload-form>
+        <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <strong class="block text-sm font-semibold text-slate-900">Open Inserto</strong>
+          <p class="mt-2 text-sm leading-6 text-slate-600">Schick mir die Fotos. Du kannst mehrere Bilder direkt auf einmal hochladen.</p>
+          <p class="mt-3 text-sm font-medium text-slate-900">Mehrfach-Upload mit Vorschau</p>
 
-        <form class="space-y-5" method="post" action="/drafts/upload" enctype="multipart/form-data" data-assistant-upload-form>
-          <div class="space-y-4 rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm">
-            <div class="flex flex-wrap items-start justify-between gap-3">
+          <label class="group mt-4 block rounded-[1.5rem] border border-dashed border-emerald-300 bg-emerald-50/70 p-6 transition hover:border-emerald-500 hover:bg-emerald-50" data-dropzone>
+            <input class="sr-only" type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
+            <div class="flex flex-col items-center justify-center gap-3 text-center">
+              <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm ring-1 ring-emerald-100">📸</div>
               <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Schritt 1</p>
-                <h2 class="mt-1 text-xl font-semibold text-slate-900">Mehrfach-Upload mit Vorschau</h2>
-                <p class="mt-2 text-sm text-slate-600">Unterstützt: JPG, PNG, WEBP, HEIC/HEIF, GIF, BMP und TIFF.</p>
+                <p class="text-base font-semibold text-slate-900">Dateien auswählen</p>
+                <p class="mt-1 text-sm text-slate-600">Oder Bilder einfach hier hineinziehen</p>
               </div>
-              <span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">Chat-Start mit Bildern</span>
+              <div class="flex flex-wrap justify-center gap-2 text-xs text-slate-500">
+                <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 1 Bild</span>
+                <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Maximal 20 Bilder</span>
+                <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 500 px</span>
+              </div>
             </div>
+          </label>
 
-            <label class="group block rounded-[1.5rem] border border-dashed border-emerald-300 bg-emerald-50/70 p-6 transition hover:border-emerald-500 hover:bg-emerald-50" data-dropzone>
-              <input class="sr-only" type="file" name="images" accept="image/*,.heic,.heif" multiple required data-image-input>
-              <div class="flex flex-col items-center justify-center gap-3 text-center">
-                <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-2xl shadow-sm ring-1 ring-emerald-100">📸</div>
-                <div>
-                  <p class="text-base font-semibold text-slate-900">Dateien auswählen</p>
-                  <p class="mt-1 text-sm text-slate-600">Oder Bilder einfach hier hineinziehen</p>
-                </div>
-                <div class="flex flex-wrap justify-center gap-2 text-xs text-slate-500">
-                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 1 Bild</span>
-                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Maximal 20 Bilder</span>
-                  <span class="rounded-full bg-white px-3 py-1 ring-1 ring-slate-200">Mindestens 500 px</span>
-                </div>
-              </div>
+          <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-preview-grid>
+            <p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>
+          </div>
+        </article>
+
+        <article class="ml-auto max-w-[92%] rounded-[1.75rem] rounded-tr-sm border border-emerald-100 bg-emerald-400 px-5 py-5 text-emerald-950 shadow-sm">
+          <strong class="block text-sm font-semibold">Du</strong>
+          <p class="mt-2 text-sm leading-6">Wenn du magst, gib mir direkt noch ein paar Hinweise mit. Das spart später Rückfragen.</p>
+
+          <div class="mt-4 grid gap-4">
+            <label class="block">
+              <span class="mb-2 block text-sm font-medium">Was soll ich über den Artikel schon wissen?</span>
+              <textarea class="min-h-28 w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Preisidee, Fundort ...">{{ form_values.notes or '' }}</textarea>
             </label>
 
-            <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-preview-grid>
-              <p class="col-span-full rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">Noch keine Bilder ausgewählt.</p>
+            <div class="grid gap-4 md:grid-cols-2">
+              {% for field_name, field_label in extra_fields %}
+                <label class="block">
+                  <span class="mb-2 block text-sm font-medium">{{ field_label }}</span>
+                  <input class="w-full rounded-2xl border-emerald-200 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-emerald-600 focus:ring-emerald-600" type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
+                </label>
+              {% endfor %}
             </div>
           </div>
+        </article>
 
-          <div class="space-y-4 rounded-[1.75rem] border border-slate-200 bg-white p-5 shadow-sm">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Schritt 2</p>
-              <h2 class="mt-1 text-xl font-semibold text-slate-900">Optionaler Gesprächskontext</h2>
-              <p class="mt-2 text-sm text-slate-600">Diese Eingaben landen direkt im Assistenten-Flow, damit Rückfragen gezielter werden.</p>
-            </div>
-
-            <div class="grid gap-4">
-              <label class="block">
-                <span class="mb-2 block text-sm font-medium text-slate-800">Was soll ich über den Artikel schon wissen?</span>
-                <textarea class="min-h-28 w-full rounded-2xl border-slate-200 bg-slate-50 px-4 py-3 text-sm shadow-sm focus:border-emerald-500 focus:ring-emerald-500" name="notes" rows="5" placeholder="Zustand, Auffälligkeiten, Preisidee, Fundort ...">{{ form_values.notes or '' }}</textarea>
-              </label>
-
-              <div class="grid gap-4 md:grid-cols-2">
-                {% for field_name, field_label in extra_fields %}
-                  <label class="block">
-                    <span class="mb-2 block text-sm font-medium text-slate-800">{{ field_label }}</span>
-                    <input class="w-full rounded-2xl border-slate-200 bg-slate-50 px-4 py-3 text-sm shadow-sm focus:border-emerald-500 focus:ring-emerald-500" type="text" name="{{ field_name }}" value="{{ form_values[field_name] if field_name in form_values else '' }}" placeholder="{{ field_label }}">
-                  </label>
-                {% endfor %}
-              </div>
-            </div>
+        <article class="max-w-[92%] rounded-[1.75rem] rounded-tl-sm bg-slate-950 px-5 py-5 text-white shadow-soft">
+          <strong class="block text-sm font-semibold text-emerald-200">Open Inserto</strong>
+          <p class="mt-2 text-sm leading-6 text-slate-100">Sobald du auf <strong>Draft erstellen</strong> tippst, starte ich direkt mit der Analyse und öffne danach den Gesprächsverlauf für die nächsten Fragen.</p>
+          <div class="mt-4 flex items-center gap-3 text-sm text-slate-300">
+            <span class="relative flex h-3 w-3">
+              <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-300 opacity-75"></span>
+              <span class="relative inline-flex h-3 w-3 rounded-full bg-emerald-300"></span>
+            </span>
+            <span>Sichtbare Analyse statt leerer Wartezeit</span>
           </div>
-
-          <div class="space-y-4 rounded-[1.75rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-soft">
-            <div class="flex items-start gap-3">
-              <div class="mt-1 flex h-11 w-11 items-center justify-center rounded-2xl bg-white/10 text-xl">🤖</div>
-              <div class="flex-1">
-                <p class="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-200">Schritt 3</p>
-                <h2 class="mt-1 text-xl font-semibold">Analyse starten</h2>
-                <p class="mt-2 text-sm leading-6 text-slate-300">Beim Absenden zeigen wir direkt eine moderne AI-Loading-Animation und wechseln danach in den Gesprächsverlauf des Drafts.</p>
-              </div>
-            </div>
-            <div class="flex flex-wrap gap-3 text-xs text-slate-300">
-              <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">Asynchroner Einstieg</span>
-              <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">Korrekturen im Chat</span>
-              <span class="rounded-full bg-white/10 px-3 py-1 ring-1 ring-white/10">Kein Formular-Zwang</span>
-            </div>
-            <button class="inline-flex items-center justify-center rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300" type="submit" data-submit-button>Draft erstellen</button>
-          </div>
-        </form>
-      </div>
-    </section>
-
-    <aside class="space-y-6">
-      <section class="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm">
-        <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">UX-Zielbild</p>
-        <h2 class="mt-2 text-2xl font-semibold tracking-tight text-slate-900">Assistenten-Flow statt Formularwüste</h2>
-        <p class="mt-3 text-sm leading-6 text-slate-600">
-          Der Upload bleibt der Einstieg. Danach bestätigt der Assistent erkannte Angaben, stellt nur gezielte Rückfragen und hält den Nutzer im selben Gesprächskontext.
-        </p>
-        <div class="mt-5 space-y-3 rounded-[1.5rem] bg-slate-950 p-4 text-sm text-white shadow-soft">
-          <article class="max-w-[90%] rounded-2xl rounded-tl-sm bg-white/10 px-4 py-3">
-            <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-200">Open Inserto</strong>
-            <p class="mt-2 leading-6 text-slate-100">Ich analysiere jetzt deine Bilder und bereite den Verkaufsentwurf vor.</p>
-          </article>
-          <article class="max-w-[90%] rounded-2xl rounded-tl-sm bg-white/10 px-4 py-3">
-            <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-200">Open Inserto</strong>
-            <p class="mt-2 leading-6 text-slate-100">Ich habe ein iPhone erkannt. Farbe und Speicher prüfe ich gleich, fehlende Angaben frage ich nur bei Unsicherheit ab.</p>
-            <div class="mt-3 flex flex-wrap gap-2">
-              <span class="rounded-full bg-emerald-400 px-3 py-1 text-xs font-semibold text-emerald-950">Super</span>
-              <span class="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white ring-1 ring-white/10">Ändern</span>
-            </div>
-          </article>
-          <article class="ml-auto max-w-[85%] rounded-2xl rounded-tr-sm bg-emerald-400 px-4 py-3 text-emerald-950">
-            <strong class="block text-xs uppercase tracking-[0.18em] text-emerald-900">Du</strong>
-            <p class="mt-2 leading-6">256 GB, Zustand ist gut, Originalkabel ist dabei.</p>
-          </article>
-        </div>
-      </section>
-
-      <section class="rounded-[2rem] border border-emerald-100 bg-emerald-50 p-6 shadow-sm">
-        <p class="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-700">AI-Animationen</p>
-        <h2 class="mt-2 text-xl font-semibold text-slate-900">Sichtbare Analyse statt leerer Wartezeit</h2>
-        <div class="mt-4 rounded-[1.5rem] bg-slate-950 p-5 text-white shadow-soft">
-          <div class="flex items-center gap-3">
-            <div class="relative h-12 w-12">
-              <span class="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping"></span>
-              <span class="absolute inset-1 rounded-full bg-emerald-400/40 animate-pulse"></span>
-              <span class="absolute inset-[10px] rounded-full bg-emerald-400"></span>
-            </div>
-            <div>
-              <p class="text-sm font-semibold text-white">Analyse läuft</p>
-              <p class="mt-1 text-sm text-slate-300">Produktmerkmale, Zustand und eBay-relevante Hinweise werden vorbereitet.</p>
-            </div>
-          </div>
-          <div class="mt-4 flex items-center gap-2">
-            <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce [animation-delay:-0.3s]"></span>
-            <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce [animation-delay:-0.15s]"></span>
-            <span class="h-2.5 w-2.5 rounded-full bg-emerald-300 animate-bounce"></span>
-          </div>
-        </div>
-      </section>
-    </aside>
+          <button class="mt-5 inline-flex items-center justify-center rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300" type="submit" data-submit-button>Draft erstellen</button>
+        </article>
+      </form>
+    </div>
   </div>
 
   <div class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-950/70 px-6 backdrop-blur-sm" data-analysis-overlay>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -363,6 +363,16 @@ ASSISTANT_FIELD_LABELS = {
 }
 
 
+ASSISTANT_PLACEHOLDER_VALUES = {
+    "",
+    "unbekannt",
+    "unknown",
+    "n/a",
+    "keine angabe",
+    "nicht erkannt",
+}
+
+
 def _assistant_flow_state(draft) -> dict[str, Any]:
     state = draft.listing.attributes.get("assistantFlow")
     return state if isinstance(state, dict) else {}
@@ -452,6 +462,26 @@ def _assistant_field_prompt(field: str) -> str:
     if field.startswith("ebay_aspect::"):
         return f"Für eBay fehlt noch { _assistant_aspect_name(field) }."
     return prompts.get(field, f"Bitte bestätige { _assistant_field_label(field).lower() }.")
+
+
+def _assistant_value_is_placeholder(value: str) -> bool:
+    normalized = value.strip().casefold()
+    if normalized in ASSISTANT_PLACEHOLDER_VALUES:
+        return True
+    return normalized.startswith("unbekannt ") or normalized.endswith(" unbekannt")
+
+
+def _assistant_response_field_values(draft) -> dict[str, str]:
+    review_values = get_review_form_values(draft)
+    category_resolution = get_category_resolution(draft)
+    return {
+        "title": draft.listing.title.strip(),
+        "condition": draft.listing.condition.strip(),
+        "included_items": review_values["included_items"],
+        "description_html": review_values["description"],
+        "category_suggestion": str(category_resolution.get("selected_name") or draft.listing.category_suggestion or "").strip(),
+        "category_suggestion_id": str(category_resolution.get("selected_id") or draft.listing.category_suggestion or "").strip(),
+    }
 
 
 def _update_single_assistant_field(draft, field: str, value: str) -> None:
@@ -602,6 +632,8 @@ def build_assistant_flow(draft) -> dict[str, Any]:
     pending_field = ""
     for field in ("title", "condition", "included_items", "description_html"):
         value = _assistant_field_value(draft, field)
+        if _assistant_value_is_placeholder(value):
+            value = ""
         label = ASSISTANT_FIELD_LABELS[field]
         if value and field in confirmed_fields:
             messages.append({
@@ -611,9 +643,10 @@ def build_assistant_flow(draft) -> dict[str, Any]:
             })
             continue
         if value:
+            value_text = value.strip() if field == "description_html" else value.splitlines()[0]
             messages.append({
                 "role": "assistant",
-                "text": f"{_assistant_field_prompt(field)}\n\n{value.splitlines()[0]}",
+                "text": f"{_assistant_field_prompt(field)}\n\n{value_text}",
                 "field": field,
                 "actions": [
                     {"kind": "confirm", "label": "Super", "field": field},
@@ -653,7 +686,12 @@ def build_assistant_flow(draft) -> dict[str, Any]:
             "tone": "confirmed",
         })
 
-    return {"messages": messages, "pendingField": pending_field, "fieldLabels": ASSISTANT_FIELD_LABELS}
+    return {
+        "messages": messages,
+        "pendingField": pending_field,
+        "fieldLabels": ASSISTANT_FIELD_LABELS,
+        "fieldValues": _assistant_response_field_values(draft),
+    }
 
 
 @router.get("/health")
@@ -962,6 +1000,9 @@ async def draft_assistant_message(request: Request, draft_id: str):
         else:
             _update_single_assistant_field(draft, field, value)
             if field == "title":
+                current_items = [item.strip() for item in draft.listing.included_items if item.strip()]
+                if len(current_items) == 1 and _dedupe_text(current_items[0]) == _dedupe_text(value):
+                    draft.listing.included_items = []
                 resolve_category_suggestion_for_draft(draft, settings)
                 autofill_ebay_required_aspects(draft, settings)
             if field.startswith("ebay_aspect::"):

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -435,7 +435,7 @@ def _assistant_field_value(draft, field: str) -> str:
             return ""
         return "\n".join(items)
     if field == "description_html":
-        return draft.source.notes.strip()
+        return get_review_form_values(draft)["description"].strip()
     return ""
 
 
@@ -456,7 +456,7 @@ def _assistant_field_prompt(field: str) -> str:
         "title": "Ich habe einen Produktnamen erkannt. Passt der so für dein Angebot?",
         "condition": "Welchen Zustand soll ich festhalten?",
         "included_items": "Was gehört alles zum Lieferumfang?",
-        "description_html": "So würde ich den Beschreibungstext aktuell formulieren. Passt das für dich?",
+        "description_html": "So würde ich den Beschreibungstext aktuell formulieren. Passt das für dich?\n\nBeschreibungsvorschlag:",
         "category_suggestion": "Welche eBay-Kategorie passt am besten?",
     }
     if field.startswith("ebay_aspect::"):
@@ -634,13 +634,7 @@ def build_assistant_flow(draft) -> dict[str, Any]:
         value = _assistant_field_value(draft, field)
         if _assistant_value_is_placeholder(value):
             value = ""
-        label = ASSISTANT_FIELD_LABELS[field]
         if value and field in confirmed_fields:
-            messages.append({
-                "role": "assistant",
-                "text": f"{label} ist bestätigt: {value.splitlines()[0]}",
-                "tone": "confirmed",
-            })
             continue
         if value:
             value_text = value.strip() if field == "description_html" else value.splitlines()[0]

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -353,6 +353,110 @@ def build_draft_result_summary(
     }
 
 
+ASSISTANT_FIELD_LABELS = {
+    "title": "Produktname",
+    "condition": "Zustand",
+    "included_items": "Lieferumfang",
+    "description_html": "Beschreibung",
+}
+
+
+def _assistant_flow_state(draft) -> dict[str, Any]:
+    state = draft.listing.attributes.get("assistantFlow")
+    return state if isinstance(state, dict) else {}
+
+
+def _assistant_flow_events(draft) -> list[dict[str, str]]:
+    events = _assistant_flow_state(draft).get("events")
+    if not isinstance(events, list):
+        return []
+    normalized: list[dict[str, str]] = []
+    for item in events:
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("role") or "").strip()
+        text = str(item.get("text") or "").strip()
+        if role and text:
+            normalized.append({"role": role, "text": text})
+    return normalized
+
+
+def _append_assistant_event(draft, *, role: str, text: str) -> None:
+    if not text.strip():
+        return
+    state = _assistant_flow_state(draft)
+    events = _assistant_flow_events(draft)
+    events.append({"role": role, "text": text.strip()})
+    state["events"] = events[-12:]
+    draft.listing.attributes["assistantFlow"] = state
+
+
+def _assistant_field_value(draft, field: str) -> str:
+    if field == "title":
+        return draft.listing.title.strip()
+    if field == "condition":
+        return draft.listing.condition.strip()
+    if field == "included_items":
+        return "\n".join(item.strip() for item in draft.listing.included_items if item.strip())
+    if field == "description_html":
+        return draft.source.notes.strip()
+    return ""
+
+
+def build_assistant_flow(draft) -> dict[str, Any]:
+    confirmed_fields = set(get_review_metadata(draft).get("confirmedFields", []))
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "text": (
+                f"Ich habe {len(draft.source.images)} Bild{'er' if len(draft.source.images) != 1 else ''} analysiert "
+                "und bereite den Verkaufsdialog Schritt für Schritt vor."
+            ),
+        }
+    ]
+    messages.extend(_assistant_flow_events(draft))
+
+    pending_field = ""
+    for field in ("title", "condition", "included_items", "description_html"):
+        value = _assistant_field_value(draft, field)
+        label = ASSISTANT_FIELD_LABELS[field]
+        if value and field in confirmed_fields:
+            messages.append({
+                "role": "assistant",
+                "text": f"{label} ist bestätigt: {value.splitlines()[0]}",
+                "tone": "confirmed",
+            })
+            continue
+        if value:
+            messages.append({
+                "role": "assistant",
+                "text": f"Ich habe {label.lower()} erkannt: {value.splitlines()[0]}",
+                "field": field,
+                "actions": [
+                    {"kind": "confirm", "label": "Super", "field": field},
+                    {"kind": "edit", "label": "Ändern", "field": field},
+                ],
+            })
+        else:
+            messages.append({
+                "role": "assistant",
+                "text": f"Bitte ergänze noch {label.lower()}.",
+                "field": field,
+                "actions": [{"kind": "edit", "label": "Antworten", "field": field}],
+            })
+        pending_field = field
+        break
+
+    if not pending_field:
+        messages.append({
+            "role": "assistant",
+            "text": "Perfekt, die Kernangaben sind bestätigt. Du kannst jetzt unten noch Feinheiten anpassen oder direkt den eBay-Schritt vorbereiten.",
+            "tone": "confirmed",
+        })
+
+    return {"messages": messages, "pendingField": pending_field, "fieldLabels": ASSISTANT_FIELD_LABELS}
+
+
 @router.get("/health")
 def health() -> dict[str, str]:
     settings = get_settings()
@@ -569,6 +673,7 @@ def draft_detail(request: Request, draft_id: str):
             review_status_label=current_review_status_label,
             review_state_label=current_review_status_label,
             display_status=display_status,
+            assistant_flow=build_assistant_flow(draft),
             show_technical_workflow_hint=(review_state != "ready" or bool(marketplace_readiness_errors)),
             core_fields=CORE_FIELDS,
             optional_fields=OPTIONAL_FIELDS,
@@ -600,6 +705,76 @@ def draft_reanalyze(request: Request, draft_id: str):
     autofill_ebay_required_aspects(draft, settings)
     repository.save_draft(draft)
     return RedirectResponse(url=f"/drafts/{draft.id}", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post("/drafts/{draft_id}/assistant/message")
+async def draft_assistant_message(request: Request, draft_id: str):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    draft = repository.get_draft(draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    payload = await request.json()
+    action = str(payload.get("action") or "").strip()
+    field = str(payload.get("field") or "").strip()
+    value = str(payload.get("value") or "").strip()
+    if field not in ASSISTANT_FIELD_LABELS:
+        raise HTTPException(status_code=400, detail="Ungültiges Feld")
+
+    confirmed_fields = set(get_review_metadata(draft).get("confirmedFields", []))
+
+    if action == "confirm":
+        confirmed_fields.add(field)
+        _append_assistant_event(draft, role="user", text="Super")
+        _append_assistant_event(draft, role="assistant", text=f"Alles klar, ich markiere {ASSISTANT_FIELD_LABELS[field].lower()} als bestätigt.")
+    elif action == "answer":
+        current_values = get_review_form_values(draft)
+        title = draft.listing.title
+        condition = draft.listing.condition
+        description = current_values["description"]
+        included_items = current_values["included_items"]
+        if field == "title":
+            title = value
+        elif field == "condition":
+            condition = value
+        elif field == "description_html":
+            description = value
+        elif field == "included_items":
+            included_items = value
+
+        confirmed_fields.add(field)
+        update_draft_from_review(
+            draft,
+            title=title,
+            condition=condition,
+            description=description,
+            included_items=included_items,
+            brand=draft.listing.brand,
+            model=draft.listing.model,
+            subtitle=draft.listing.subtitle,
+            category_suggestion=draft.listing.category_suggestion,
+            hints=current_values["hints"],
+            product_identifier_type=current_values["product_identifier_type"],
+            product_identifier_value=current_values["product_identifier_value"],
+            key_technical_details=current_values["key_technical_details"],
+            shipping_profile=get_selected_shipping_profile(draft),
+            confirm_fields=sorted(confirmed_fields),
+            action="confirm",
+        )
+        _append_assistant_event(draft, role="user", text=value)
+        _append_assistant_event(draft, role="assistant", text=f"Danke, ich habe {ASSISTANT_FIELD_LABELS[field].lower()} aktualisiert.")
+    elif action != "edit":
+        raise HTTPException(status_code=400, detail="Ungültige Aktion")
+
+    if action == "confirm":
+        draft.listing.attributes["review"] = {
+            **get_review_metadata(draft),
+            "confirmedFields": sorted(confirmed_fields),
+        }
+
+    repository.save_draft(draft)
+    return JSONResponse({"ok": True, **build_assistant_flow(draft)})
 
 
 @router.post("/drafts/{draft_id}/review", response_class=HTMLResponse)

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -1,4 +1,3 @@
-from html import unescape
 from pathlib import Path
 import re
 from dataclasses import dataclass
@@ -421,11 +420,17 @@ def _assistant_field_value(draft, field: str) -> str:
     if field == "condition":
         return draft.listing.condition.strip()
     if field == "included_items":
-        return "\n".join(item.strip() for item in draft.listing.included_items if item.strip())
+        items = [item.strip() for item in draft.listing.included_items if item.strip()]
+        if len(items) == 1 and _dedupe_text(items[0]) == _dedupe_text(draft.listing.title):
+            return ""
+        return "\n".join(items)
     if field == "description_html":
-        plain = re.sub(r"<[^>]+>", " ", draft.listing.description_html or "")
-        return re.sub(r"\s+", " ", unescape(plain)).strip()
+        return draft.source.notes.strip()
     return ""
+
+
+def _dedupe_text(value: str) -> str:
+    return re.sub(r"[^a-z0-9äöüß]+", " ", value.casefold()).strip()
 
 
 def _assistant_field_label(field: str) -> str:
@@ -941,6 +946,7 @@ async def draft_assistant_message(request: Request, draft_id: str):
         _append_assistant_event(draft, role="user", text="Super")
         _append_assistant_event(draft, role="assistant", text=f"Alles klar, { _assistant_field_label(field) } ist übernommen.")
     elif action in {"answer", "select"}:
+        field_completed = True
         if field == "category_suggestion":
             draft.listing.category_suggestion = value
             resolve_category_suggestion_for_draft(
@@ -949,6 +955,10 @@ async def draft_assistant_message(request: Request, draft_id: str):
                 preserve_numeric_id=bool(value and value.isdigit()),
             )
             autofill_ebay_required_aspects(draft, settings)
+            category_resolution = get_category_resolution(draft)
+            category_state = str(category_resolution.get("state") or "")
+            selected_id = str(category_resolution.get("selected_id") or draft.listing.category_suggestion or "").strip()
+            field_completed = bool(selected_id) and category_state not in {"needs_selection", "no_match", "lookup_failed", "config_missing", "empty"}
         else:
             _update_single_assistant_field(draft, field, value)
             if field == "title":
@@ -956,11 +966,17 @@ async def draft_assistant_message(request: Request, draft_id: str):
                 autofill_ebay_required_aspects(draft, settings)
             if field.startswith("ebay_aspect::"):
                 autofill_ebay_required_aspects(draft, settings)
-        if field in ASSISTANT_FIELD_LABELS:
+        if field_completed and field in ASSISTANT_FIELD_LABELS:
             confirmed_fields.add(field)
-        assistant_confirmed_fields.add(field)
+        if field_completed:
+            assistant_confirmed_fields.add(field)
+        else:
+            assistant_confirmed_fields.discard(field)
         _append_assistant_event(draft, role="user", text=value)
-        _append_assistant_event(draft, role="assistant", text=f"Danke, ich habe { _assistant_field_label(field) } aktualisiert.")
+        if field == "category_suggestion" and not field_completed:
+            _append_assistant_event(draft, role="assistant", text="Ich habe dazu neue eBay-Kategorievorschläge gesucht.")
+        else:
+            _append_assistant_event(draft, role="assistant", text=f"Danke, ich habe { _assistant_field_label(field) } aktualisiert.")
     elif action != "edit":
         raise HTTPException(status_code=400, detail="Ungültige Aktion")
 

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -358,6 +358,7 @@ ASSISTANT_FIELD_LABELS = {
     "condition": "Zustand",
     "included_items": "Lieferumfang",
     "description_html": "Beschreibung",
+    "category_suggestion": "eBay-Kategorie",
 }
 
 
@@ -391,6 +392,27 @@ def _append_assistant_event(draft, *, role: str, text: str) -> None:
     draft.listing.attributes["assistantFlow"] = state
 
 
+def _assistant_confirmed_fields(draft) -> set[str]:
+    fields = _assistant_flow_state(draft).get("confirmedFields")
+    if not isinstance(fields, list):
+        return set()
+    return {str(item).strip() for item in fields if str(item).strip()}
+
+
+def _set_assistant_confirmed_fields(draft, fields: set[str]) -> None:
+    state = _assistant_flow_state(draft)
+    state["confirmedFields"] = sorted(field for field in fields if field)
+    draft.listing.attributes["assistantFlow"] = state
+
+
+def _assistant_aspect_field(aspect_name: str) -> str:
+    return f"ebay_aspect::{aspect_name.strip()}"
+
+
+def _assistant_aspect_name(field: str) -> str:
+    return field.removeprefix("ebay_aspect::").strip()
+
+
 def _assistant_field_value(draft, field: str) -> str:
     if field == "title":
         return draft.listing.title.strip()
@@ -403,8 +425,139 @@ def _assistant_field_value(draft, field: str) -> str:
     return ""
 
 
+def _assistant_field_label(field: str) -> str:
+    if field in ASSISTANT_FIELD_LABELS:
+        return ASSISTANT_FIELD_LABELS[field]
+    if field.startswith("ebay_aspect::"):
+        return _assistant_aspect_name(field)
+    return field
+
+
+def _update_single_assistant_field(draft, field: str, value: str) -> None:
+    current_values = get_review_form_values(draft)
+    title = draft.listing.title
+    condition = draft.listing.condition
+    description = current_values["description"]
+    included_items = current_values["included_items"]
+    category_suggestion = draft.listing.category_suggestion
+    ebay_aspects = get_ebay_aspect_values(draft)
+
+    if field == "title":
+        title = value
+    elif field == "condition":
+        condition = value
+    elif field == "description_html":
+        description = value
+    elif field == "included_items":
+        included_items = value
+    elif field == "category_suggestion":
+        category_suggestion = value
+    elif field.startswith("ebay_aspect::"):
+        aspect_name = _assistant_aspect_name(field)
+        if value.strip():
+            ebay_aspects[aspect_name] = value.strip()
+        else:
+            ebay_aspects.pop(aspect_name, None)
+
+    update_draft_from_review(
+        draft,
+        title=title,
+        condition=condition,
+        description=description,
+        included_items=included_items,
+        brand=draft.listing.brand,
+        model=draft.listing.model,
+        subtitle=draft.listing.subtitle,
+        category_suggestion=category_suggestion,
+        hints=current_values["hints"],
+        product_identifier_type=current_values["product_identifier_type"],
+        product_identifier_value=current_values["product_identifier_value"],
+        key_technical_details=current_values["key_technical_details"],
+        shipping_profile=get_selected_shipping_profile(draft),
+        confirm_fields=get_review_metadata(draft).get("confirmedFields", []),
+        action="confirm",
+    )
+    if ebay_aspects:
+        draft.listing.attributes["ebayAspects"] = ebay_aspects
+    else:
+        draft.listing.attributes.pop("ebayAspects", None)
+
+
+def _build_assistant_category_message(draft) -> dict[str, Any] | None:
+    category_resolution = get_category_resolution(draft)
+    state = str(category_resolution.get("state") or "")
+    selected_id = str(category_resolution.get("selected_id") or draft.listing.category_suggestion or "").strip()
+    selected_name = str(category_resolution.get("selected_name") or "").strip()
+
+    if state == "needs_selection":
+        suggestions = category_resolution.get("suggestions") if isinstance(category_resolution.get("suggestions"), list) else []
+        actions = []
+        for item in suggestions[:4]:
+            if not isinstance(item, dict):
+                continue
+            category_id = str(item.get("id") or "").strip()
+            label = str(item.get("name") or category_id).strip()
+            if category_id and label:
+                actions.append({"kind": "select", "label": label[:48], "field": "category_suggestion", "value": category_id})
+        return {
+            "role": "assistant",
+            "text": str(category_resolution.get("message") or "Ich habe mehrere passende eBay-Kategorien gefunden. Wähle bitte die beste aus oder antworte mit einem anderen Suchbegriff."),
+            "field": "category_suggestion",
+            "actions": actions or [{"kind": "edit", "label": "Anderen Begriff senden", "field": "category_suggestion"}],
+        }
+
+    if selected_id:
+        return {
+            "role": "assistant",
+            "text": f"Ich würde für eBay aktuell diese Kategorie verwenden: {selected_name or selected_id}.",
+            "field": "category_suggestion",
+            "actions": [
+                {"kind": "confirm", "label": "Passt", "field": "category_suggestion"},
+                {"kind": "edit", "label": "Kategorie ändern", "field": "category_suggestion"},
+            ],
+        }
+
+    return {
+        "role": "assistant",
+        "text": "Damit der eBay-Teil später sauber läuft, brauche ich noch eine passende Kategorie. Antworte mit einem Suchbegriff oder direkt mit einer eBay-Kategorie-ID.",
+        "field": "category_suggestion",
+        "actions": [{"kind": "edit", "label": "Kategorie angeben", "field": "category_suggestion"}],
+    }
+
+
+def _build_assistant_aspect_message(draft) -> dict[str, Any] | None:
+    aspect_values = get_ebay_aspect_values(draft)
+    for aspect in get_required_category_aspects(draft):
+        name = str(aspect.get("name") or "").strip()
+        if not name:
+            continue
+        field = _assistant_aspect_field(name)
+        value = aspect_values.get(name, "").strip()
+        options = [str(item).strip() for item in aspect.get("values") or [] if str(item).strip()][:4]
+        if value:
+            return {
+                "role": "assistant",
+                "text": f"Für {name} habe ich aktuell diesen Wert: {value}.",
+                "field": field,
+                "actions": [
+                    {"kind": "confirm", "label": "Passt", "field": field},
+                    {"kind": "edit", "label": "Wert ändern", "field": field},
+                ],
+            }
+        actions = [{"kind": "select", "label": option[:40], "field": field, "value": option} for option in options]
+        actions.append({"kind": "edit", "label": "Selbst eingeben", "field": field})
+        return {
+            "role": "assistant",
+            "text": f"Für die eBay-Kategorie fehlt noch {name}.",
+            "field": field,
+            "actions": actions,
+        }
+    return None
+
+
 def build_assistant_flow(draft) -> dict[str, Any]:
     confirmed_fields = set(get_review_metadata(draft).get("confirmedFields", []))
+    assistant_confirmed_fields = _assistant_confirmed_fields(draft)
     messages: list[dict[str, Any]] = [
         {
             "role": "assistant",
@@ -448,9 +601,21 @@ def build_assistant_flow(draft) -> dict[str, Any]:
         break
 
     if not pending_field:
+        category_message = _build_assistant_category_message(draft)
+        if category_message and str(category_message.get("field") or "") not in assistant_confirmed_fields:
+            messages.append(category_message)
+            pending_field = str(category_message.get("field") or "")
+
+    if not pending_field:
+        aspect_message = _build_assistant_aspect_message(draft)
+        if aspect_message and str(aspect_message.get("field") or "") not in assistant_confirmed_fields:
+            messages.append(aspect_message)
+            pending_field = str(aspect_message.get("field") or "")
+
+    if not pending_field:
         messages.append({
             "role": "assistant",
-            "text": "Perfekt, die Kernangaben sind bestätigt. Du kannst jetzt unten noch Feinheiten anpassen oder direkt den eBay-Schritt vorbereiten.",
+            "text": "Perfekt, der Chat hat jetzt auch die eBay-relevanten Angaben zusammen. Du kannst unten nur noch optional feinjustieren oder direkt den eBay-Schritt vorbereiten.",
             "tone": "confirmed",
         })
 
@@ -586,6 +751,21 @@ async def upload_draft(
             await image.close()
 
     repository.save_draft(result.draft)
+    wants_json = "application/json" in str(request.headers.get("accept") or "")
+    if wants_json:
+        return JSONResponse(
+            {
+                "ok": True,
+                "draftId": result.draft.id,
+                "location": f"/drafts/{result.draft.id}",
+                "assistant": build_assistant_flow(result.draft),
+                "images": [
+                    {"name": image.original_filename, "url": f"/{image.storage_path}", "order": image.order}
+                    for image in result.draft.source.images
+                ],
+                "notes": result.draft.source.notes,
+            }
+        )
     return RedirectResponse(url=f"/drafts/{result.draft.id}", status_code=status.HTTP_303_SEE_OTHER)
 
 
@@ -719,62 +899,71 @@ async def draft_assistant_message(request: Request, draft_id: str):
     action = str(payload.get("action") or "").strip()
     field = str(payload.get("field") or "").strip()
     value = str(payload.get("value") or "").strip()
-    if field not in ASSISTANT_FIELD_LABELS:
+    if field not in ASSISTANT_FIELD_LABELS and not field.startswith("ebay_aspect::"):
         raise HTTPException(status_code=400, detail="Ungültiges Feld")
 
     confirmed_fields = set(get_review_metadata(draft).get("confirmedFields", []))
+    assistant_confirmed_fields = _assistant_confirmed_fields(draft)
 
     if action == "confirm":
-        confirmed_fields.add(field)
+        if field in ASSISTANT_FIELD_LABELS:
+            confirmed_fields.add(field)
+        assistant_confirmed_fields.add(field)
         _append_assistant_event(draft, role="user", text="Super")
-        _append_assistant_event(draft, role="assistant", text=f"Alles klar, ich markiere {ASSISTANT_FIELD_LABELS[field].lower()} als bestätigt.")
-    elif action == "answer":
-        current_values = get_review_form_values(draft)
-        title = draft.listing.title
-        condition = draft.listing.condition
-        description = current_values["description"]
-        included_items = current_values["included_items"]
-        if field == "title":
-            title = value
-        elif field == "condition":
-            condition = value
-        elif field == "description_html":
-            description = value
-        elif field == "included_items":
-            included_items = value
-
-        confirmed_fields.add(field)
-        update_draft_from_review(
-            draft,
-            title=title,
-            condition=condition,
-            description=description,
-            included_items=included_items,
-            brand=draft.listing.brand,
-            model=draft.listing.model,
-            subtitle=draft.listing.subtitle,
-            category_suggestion=draft.listing.category_suggestion,
-            hints=current_values["hints"],
-            product_identifier_type=current_values["product_identifier_type"],
-            product_identifier_value=current_values["product_identifier_value"],
-            key_technical_details=current_values["key_technical_details"],
-            shipping_profile=get_selected_shipping_profile(draft),
-            confirm_fields=sorted(confirmed_fields),
-            action="confirm",
-        )
+        _append_assistant_event(draft, role="assistant", text=f"Alles klar, ich markiere {_assistant_field_label(field).lower()} als bestätigt.")
+    elif action in {"answer", "select"}:
+        if field == "category_suggestion":
+            draft.listing.category_suggestion = value
+            resolve_category_suggestion_for_draft(
+                draft,
+                settings,
+                preserve_numeric_id=bool(value and value.isdigit()),
+            )
+            autofill_ebay_required_aspects(draft, settings)
+        else:
+            _update_single_assistant_field(draft, field, value)
+            if field.startswith("ebay_aspect::"):
+                autofill_ebay_required_aspects(draft, settings)
+        if field in ASSISTANT_FIELD_LABELS:
+            confirmed_fields.add(field)
+        assistant_confirmed_fields.add(field)
         _append_assistant_event(draft, role="user", text=value)
-        _append_assistant_event(draft, role="assistant", text=f"Danke, ich habe {ASSISTANT_FIELD_LABELS[field].lower()} aktualisiert.")
+        _append_assistant_event(draft, role="assistant", text=f"Danke, ich habe {_assistant_field_label(field).lower()} aktualisiert.")
     elif action != "edit":
         raise HTTPException(status_code=400, detail="Ungültige Aktion")
 
-    if action == "confirm":
+    if action == "confirm" or field in ASSISTANT_FIELD_LABELS:
         draft.listing.attributes["review"] = {
             **get_review_metadata(draft),
             "confirmedFields": sorted(confirmed_fields),
         }
 
+    _set_assistant_confirmed_fields(draft, assistant_confirmed_fields)
+
     repository.save_draft(draft)
     return JSONResponse({"ok": True, **build_assistant_flow(draft)})
+
+
+@router.get("/drafts/{draft_id}/assistant/state")
+def draft_assistant_state(draft_id: str):
+    settings = get_settings()
+    repository = DraftRepository(settings.database_path)
+    draft = repository.get_draft(draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "draftId": draft.id,
+            "assistant": build_assistant_flow(draft),
+            "images": [
+                {"name": image.original_filename, "url": f"/{image.storage_path}", "order": image.order}
+                for image in draft.source.images
+            ],
+            "notes": draft.source.notes,
+        }
+    )
 
 
 @router.post("/drafts/{draft_id}/review", response_class=HTMLResponse)

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -1,4 +1,6 @@
+from html import unescape
 from pathlib import Path
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -421,7 +423,8 @@ def _assistant_field_value(draft, field: str) -> str:
     if field == "included_items":
         return "\n".join(item.strip() for item in draft.listing.included_items if item.strip())
     if field == "description_html":
-        return draft.source.notes.strip()
+        plain = re.sub(r"<[^>]+>", " ", draft.listing.description_html or "")
+        return re.sub(r"\s+", " ", unescape(plain)).strip()
     return ""
 
 
@@ -431,6 +434,19 @@ def _assistant_field_label(field: str) -> str:
     if field.startswith("ebay_aspect::"):
         return _assistant_aspect_name(field)
     return field
+
+
+def _assistant_field_prompt(field: str) -> str:
+    prompts = {
+        "title": "Ich habe einen Produktnamen erkannt. Passt der so für dein Angebot?",
+        "condition": "Welchen Zustand soll ich festhalten?",
+        "included_items": "Was gehört alles zum Lieferumfang?",
+        "description_html": "So würde ich den Beschreibungstext aktuell formulieren. Passt das für dich?",
+        "category_suggestion": "Welche eBay-Kategorie passt am besten?",
+    }
+    if field.startswith("ebay_aspect::"):
+        return f"Für eBay fehlt noch { _assistant_aspect_name(field) }."
+    return prompts.get(field, f"Bitte bestätige { _assistant_field_label(field).lower() }.")
 
 
 def _update_single_assistant_field(draft, field: str, value: str) -> None:
@@ -483,6 +499,27 @@ def _update_single_assistant_field(draft, field: str, value: str) -> None:
         draft.listing.attributes.pop("ebayAspects", None)
 
 
+def _category_suggestion_actions(draft, *, include_confirm: bool) -> list[dict[str, str]]:
+    category_resolution = get_category_resolution(draft)
+    suggestions = category_resolution.get("suggestions") if isinstance(category_resolution.get("suggestions"), list) else []
+    selected_id = str(category_resolution.get("selected_id") or draft.listing.category_suggestion or "").strip()
+    actions: list[dict[str, str]] = []
+    if include_confirm and selected_id:
+        actions.append({"kind": "confirm", "label": "Passt", "field": "category_suggestion"})
+    for item in suggestions[:4]:
+        if not isinstance(item, dict):
+            continue
+        category_id = str(item.get("id") or "").strip()
+        label = str(item.get("name") or category_id).strip()
+        if not category_id or not label or category_id == selected_id:
+            continue
+        actions.append({"kind": "select", "label": label[:48], "field": "category_suggestion", "value": category_id})
+        if len(actions) >= (5 if include_confirm else 4):
+            break
+    actions.append({"kind": "edit", "label": "Eigene Suche", "field": "category_suggestion"})
+    return actions
+
+
 def _build_assistant_category_message(draft) -> dict[str, Any] | None:
     category_resolution = get_category_resolution(draft)
     state = str(category_resolution.get("state") or "")
@@ -490,20 +527,11 @@ def _build_assistant_category_message(draft) -> dict[str, Any] | None:
     selected_name = str(category_resolution.get("selected_name") or "").strip()
 
     if state == "needs_selection":
-        suggestions = category_resolution.get("suggestions") if isinstance(category_resolution.get("suggestions"), list) else []
-        actions = []
-        for item in suggestions[:4]:
-            if not isinstance(item, dict):
-                continue
-            category_id = str(item.get("id") or "").strip()
-            label = str(item.get("name") or category_id).strip()
-            if category_id and label:
-                actions.append({"kind": "select", "label": label[:48], "field": "category_suggestion", "value": category_id})
         return {
             "role": "assistant",
             "text": str(category_resolution.get("message") or "Ich habe mehrere passende eBay-Kategorien gefunden. Wähle bitte die beste aus oder antworte mit einem anderen Suchbegriff."),
             "field": "category_suggestion",
-            "actions": actions or [{"kind": "edit", "label": "Anderen Begriff senden", "field": "category_suggestion"}],
+            "actions": _category_suggestion_actions(draft, include_confirm=False),
         }
 
     if selected_id:
@@ -511,10 +539,7 @@ def _build_assistant_category_message(draft) -> dict[str, Any] | None:
             "role": "assistant",
             "text": f"Ich würde für eBay aktuell diese Kategorie verwenden: {selected_name or selected_id}.",
             "field": "category_suggestion",
-            "actions": [
-                {"kind": "confirm", "label": "Passt", "field": "category_suggestion"},
-                {"kind": "edit", "label": "Kategorie ändern", "field": "category_suggestion"},
-            ],
+            "actions": _category_suggestion_actions(draft, include_confirm=True),
         }
 
     return {
@@ -583,7 +608,7 @@ def build_assistant_flow(draft) -> dict[str, Any]:
         if value:
             messages.append({
                 "role": "assistant",
-                "text": f"Ich habe {label.lower()} erkannt: {value.splitlines()[0]}",
+                "text": f"{_assistant_field_prompt(field)}\n\n{value.splitlines()[0]}",
                 "field": field,
                 "actions": [
                     {"kind": "confirm", "label": "Super", "field": field},
@@ -593,7 +618,7 @@ def build_assistant_flow(draft) -> dict[str, Any]:
         else:
             messages.append({
                 "role": "assistant",
-                "text": f"Bitte ergänze noch {label.lower()}.",
+                "text": _assistant_field_prompt(field),
                 "field": field,
                 "actions": [{"kind": "edit", "label": "Antworten", "field": field}],
             })
@@ -615,7 +640,11 @@ def build_assistant_flow(draft) -> dict[str, Any]:
     if not pending_field:
         messages.append({
             "role": "assistant",
-            "text": "Perfekt, der Chat hat jetzt auch die eBay-relevanten Angaben zusammen. Du kannst unten nur noch optional feinjustieren oder direkt den eBay-Schritt vorbereiten.",
+            "text": "Perfekt, der Chat hat jetzt auch die eBay-relevanten Angaben zusammen. Wenn du willst, kannst du jetzt direkt den finalen Entwurf prüfen oder sofort den eBay-Schritt vorbereiten.",
+            "actions": [
+                {"kind": "link", "label": "Finalen Entwurf prüfen", "href": "#listing-editor"},
+                {"kind": "link", "label": "eBay-Schritt öffnen", "href": "#ebay-send"},
+            ],
             "tone": "confirmed",
         })
 
@@ -910,7 +939,7 @@ async def draft_assistant_message(request: Request, draft_id: str):
             confirmed_fields.add(field)
         assistant_confirmed_fields.add(field)
         _append_assistant_event(draft, role="user", text="Super")
-        _append_assistant_event(draft, role="assistant", text=f"Alles klar, ich markiere {_assistant_field_label(field).lower()} als bestätigt.")
+        _append_assistant_event(draft, role="assistant", text=f"Alles klar, { _assistant_field_label(field) } ist übernommen.")
     elif action in {"answer", "select"}:
         if field == "category_suggestion":
             draft.listing.category_suggestion = value
@@ -922,13 +951,16 @@ async def draft_assistant_message(request: Request, draft_id: str):
             autofill_ebay_required_aspects(draft, settings)
         else:
             _update_single_assistant_field(draft, field, value)
+            if field == "title":
+                resolve_category_suggestion_for_draft(draft, settings)
+                autofill_ebay_required_aspects(draft, settings)
             if field.startswith("ebay_aspect::"):
                 autofill_ebay_required_aspects(draft, settings)
         if field in ASSISTANT_FIELD_LABELS:
             confirmed_fields.add(field)
         assistant_confirmed_fields.add(field)
         _append_assistant_event(draft, role="user", text=value)
-        _append_assistant_event(draft, role="assistant", text=f"Danke, ich habe {_assistant_field_label(field).lower()} aktualisiert.")
+        _append_assistant_event(draft, role="assistant", text=f"Danke, ich habe { _assistant_field_label(field) } aktualisiert.")
     elif action != "edit":
         raise HTTPException(status_code=400, detail="Ungültige Aktion")
 

--- a/docs/adr/0018-conversational-assisted-selling-ui.md
+++ b/docs/adr/0018-conversational-assisted-selling-ui.md
@@ -1,0 +1,164 @@
+# ADR 0018 – Konversationeller Assisted-Selling-Flow
+
+## Status
+
+Accepted
+
+Ergänzt ADR 0001, konkretisiert Issue #27 und beschreibt die nächste UX-Ausbaustufe nach dem aktuellen MVP-Review-Flow.
+
+## Kontext
+
+Der aktuelle MVP funktioniert, fühlt sich aber noch wie ein klassischer Draft-Editor an:
+
+- Bilder hochladen
+- KI-Vorschlag prüfen
+- viele Felder auf einer Detailseite bearbeiten
+- eBay-spezifische Pflichtangaben manuell ergänzen
+
+Für das Zielbild von Open Inserto reicht das mittelfristig nicht.
+
+Der gewünschte Flow soll stärker einem Assistenten-Dialog ähneln:
+
+- Einstieg über Bilder
+- sichtbare Analysephase
+- erkannte Angaben werden aktiv bestätigt oder korrigiert
+- Rückfragen erscheinen nur bei Unsicherheit oder Pflichtbedarf
+- Antworten erfolgen bevorzugt über Buttons, Chips oder kurze Freitexte
+- neue Nachrichten laden dynamisch nach, ohne Full-Page-Reload
+
+## Entscheidung
+
+Open Inserto entwickelt die nächste UX-Stufe als **chat-artigen Assisted-Selling-Flow** auf Basis der bestehenden FastAPI/Jinja-Architektur weiter.
+
+### Bevorzugter UI-Stack
+
+- **Tailwind CSS** für das Design-System und mobile-first UI
+- **HTMX** für servernahe, fragmentbasierte Interaktionen
+- **Alpine.js** für kleine lokale UI-States
+- **SSE bevorzugt**, optional WebSockets, für dynamische Assistenten-Nachrichten ohne klassischen Reload-Flow
+
+Ein großer SPA-Neubau mit React, Next.js oder Vue ist für diese Phase nicht die bevorzugte Richtung.
+
+## Begründung
+
+### Warum Tailwind CSS
+
+- schnell konsistente UI-Bausteine aufbauen
+- gute Kontrolle über Spacing, States und Responsive-Verhalten
+- passt gut zu einer kleinen serverseitigen Anwendung ohne komplexe Frontend-Build-Architektur als Zwang
+
+### Warum HTMX
+
+- harmoniert mit FastAPI und serverseitigem HTML-Rendering
+- reduziert Frontend-Komplexität im Vergleich zu einem SPA
+- eignet sich gut für fragmentbasierte Schritte wie neue Assistenten-Nachrichten, Bestätigungen und Auswahloptionen
+
+### Warum Alpine.js
+
+- genug für Scroll-to-bottom, Button-States, Composer-Zustand, Loading-Indikatoren und kleine UI-Maschinen
+- deutlich leichter als ein vollwertiges Component-Framework
+
+### Warum SSE zuerst
+
+- neue Assistenten-Nachrichten können serverseitig inkrementell ausgeliefert werden
+- geringerer Architektur- und Betriebsaufwand als bidirektionale Echtzeit-Logik für jeden Schritt
+- reicht für das gewünschte Gefühl eines lebendigen, asynchronen Dialogs oft aus
+
+## Zielbild der Interaktion
+
+1. Nutzer lädt Bilder hoch.
+2. Die Oberfläche zeigt direkt im Conversation-Stream einen Analysezustand.
+3. Der Assistent sendet eine erste Zusammenfassung des erkannten Artikels.
+4. Erfasste Attribute werden explizit bestätigt oder zur Korrektur angeboten.
+5. Offene oder unsichere Angaben werden priorisiert abgefragt.
+6. Der Server entscheidet nach jeder Antwort, welche nächste Frage den größten Erkenntnisgewinn bringt.
+7. Am Ende erscheint eine kompakte Review- und Publish-Freigabe im selben Flow.
+
+## Produktregeln
+
+### 1. Bestätigung vor stiller Übernahme
+
+Automatisch erkannte Daten sollen nicht unsichtbar übernommen werden. Der Nutzer muss relevante Erkennungen nachvollziehen und bei Bedarf korrigieren können.
+
+Beispiel:
+
+- „Ich habe die Farbe Schwarz erkannt.“
+- Aktionen: `Super`, `Ändern`
+
+### 2. Fragen nur bei echtem Mehrwert
+
+Die Conversation Engine soll nur fragen, wenn:
+
+- ein Pflichtwert fehlt
+- die Erkennung unsicher ist
+- mehrere plausible Varianten vorliegen
+- ein Marktplatzfeld ohne Nutzersicht riskant wäre
+
+### 3. Antwortmodus passend zum Feld
+
+Je nach Feldtyp:
+
+- Buttons / Chips für klare Auswahlmöglichkeiten
+- Ja/Nein für Bestätigungen
+- Freitext für offene Angaben
+- Korrekturpfade für bereits erkannte Werte
+
+### 4. eBay-Komplexität progressive offenlegen
+
+Die Standard-UX bleibt menschlich und verkaufsorientiert. Technische eBay-Strukturen werden erst dann prominent sichtbar, wenn sie für den nächsten Schritt nötig sind.
+
+## Architekturfolgen
+
+### Servermodell
+
+Neben dem bestehenden Draft-Modell wird ein Conversation-Modell benötigt, mindestens mit:
+
+- Nachrichten
+- Sprecherrolle
+- Nachrichtentyp
+- Antwortoptionen
+- referenziertem Feld / Attribut
+- Confidence bzw. Entscheidungsgrund
+
+### UI-Bausteine
+
+Benötigte Komponenten:
+
+- Chat-Layout
+- Message-Bubbles
+- Choice-Buttons / Chips
+- Composer für Freitext
+- Analyse- / Typing-State
+- kompakte Review- / Publish-Karte
+
+### Migrationsstrategie
+
+Die aktuelle Draft-Seite bleibt zunächst funktional. Der neue Assistenten-Flow wird schrittweise aufgebaut, statt den funktionierenden MVP-Workflow in einem großen Umbau zu ersetzen.
+
+## Umsetzungsphasen
+
+### Phase 1 – Design-System und Conversation-Shell
+
+- Tailwind einführen
+- visuelle Tokens und wiederverwendbare Komponenten definieren
+- Upload und Draft-Einstieg auf Conversation-UX ausrichten
+- statische bzw. serverseitig vorbereitete Assistenten-Sektionen ergänzen
+
+### Phase 2 – Dynamische Conversation
+
+- HTMX-gestützte Nachrichtenschritte
+- SSE- oder WebSocket-basierte neue Assistenten-Nachrichten
+- Bestätigen / Ändern / Nachfragen als echte Interaktionsmuster
+
+### Phase 3 – Priorisierte Fragen-Engine
+
+- Confidence-basierte Frageauswahl
+- Korrektur-Loops für erkannte Attribute
+- Review- und Publish-Freigabe im Conversation-Stream
+
+## Konsequenzen
+
+- Die bestehende FastAPI/Jinja-Architektur bleibt vorerst erhalten.
+- Ein SPA-Neubau ist aktuell kein Standardpfad.
+- UX-Arbeit priorisiert mobile-first, dynamische Conversations und progressive Offenlegung statt größerer Formularseiten.
+- Dokumentation und künftige UI-Änderungen sollten sich an diesem Zielbild orientieren.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -31,8 +31,8 @@ In der ersten Ausbaustufe liegt der Fokus auf eBay und einem sicheren Draft-Work
 
 ## Nächste Schritte
 
-1. Tech-Stack festlegen
-2. internes Draft-Datenmodell definieren
-3. Template-Platzhalter festlegen
-4. eBay Auth-/API-Setup klären
-5. MVP für „Bilder → Draft-Daten → HTML → eBay Draft“ bauen
+1. bestehendes MVP stabil halten und den Review-Flow weiter absichern
+2. Conversation-Modell für Assistenten-Nachrichten und Antwortoptionen ergänzen
+3. Design-System und mobile-first UI auf Basis des in ADR 0018 beschriebenen Stacks aufbauen
+4. dynamische Nachrichten-Updates ohne Full-Page-Reload einführen
+5. Review und Publish schrittweise in einen chat-artigen Assisted-Selling-Flow überführen

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -226,9 +226,54 @@ def test_draft_assistant_uses_updated_title_for_follow_up_steps(client: TestClie
     assert payload["ok"] is True
     assert any("Produktname aktualisiert" in message["text"] for message in payload["messages"])
     assert any("DALI Rubikore 6 + DALI Rubikore Cinema" in message["text"] for message in payload["messages"])
+    assert payload["fieldValues"]["title"] == "DALI Rubikore 6 + DALI Rubikore Cinema"
 
     updated_detail = client.get(location)
     assert "DALI Rubikore 6 + DALI Rubikore Cinema" in updated_detail.text
+
+
+def test_draft_assistant_does_not_keep_product_title_as_only_included_item(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "Jurassic World T-Rex Spielzeugfigur", "condition": "neu", "notes": "Mattel Figur"},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+
+    assistant = client.post(
+        f"{location}/assistant/message",
+        json={"action": "answer", "field": "title", "value": "Jurassic World T-Rex Spielzeugfigur"},
+    )
+
+    assert assistant.status_code == 200
+    payload = assistant.json()
+    assert payload["ok"] is True
+    assert not any("Was gehört alles zum Lieferumfang?\n\nJurassic World T-Rex Spielzeugfigur" == message["text"] for message in payload["messages"])
+
+
+def test_draft_assistant_treats_unknown_values_as_unanswered(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "Porsche 911 Carrera S Cabriolet", "condition": "unbekannt", "notes": "Modellauto"},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+    client.post(
+        f"{location}/assistant/message",
+        json={"action": "confirm", "field": "title"},
+    )
+
+    state = client.get(f"{location}/assistant/state")
+    payload = state.json()["assistant"]
+    assert payload["pendingField"] == "condition"
+    condition_message = next(message for message in payload["messages"] if message.get("field") == "condition")
+    assert condition_message["text"] == "Welchen Zustand soll ich festhalten?"
 
 
 def test_draft_assistant_can_confirm_category_without_page_reload(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -232,6 +232,32 @@ def test_draft_assistant_uses_updated_title_for_follow_up_steps(client: TestClie
     assert "DALI Rubikore 6 + DALI Rubikore Cinema" in updated_detail.text
 
 
+def test_draft_assistant_keeps_confirmed_messages_stable_without_replaying_old_prompts(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "iPhone", "condition": "gut", "notes": "Leichte Spuren", "accessories": "Ladekabel"},
+        headers={"Accept": "application/json"},
+    )
+
+    draft_id = response.json()["draftId"]
+    first_state = client.get(f"/drafts/{draft_id}/assistant/state").json()["assistant"]
+    first_title_prompts = [message for message in first_state["messages"] if "Ich habe einen Produktnamen erkannt." in message["text"]]
+    assert len(first_title_prompts) == 1
+
+    reply = client.post(
+        f"/drafts/{draft_id}/assistant/message",
+        json={"action": "confirm", "field": "title"},
+    )
+
+    assert reply.status_code == 200
+    payload = reply.json()
+    assert sum(1 for message in payload["messages"] if "Ich habe einen Produktnamen erkannt." in message["text"]) == 0
+    assert any(message["text"] == "Alles klar, Produktname ist übernommen." for message in payload["messages"])
+    assert any(message["text"].startswith("Welchen Zustand soll ich festhalten?") for message in payload["messages"])
+
+
 def test_draft_assistant_does_not_keep_product_title_as_only_included_item(client: TestClient):
     files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
     response = client.post(
@@ -252,6 +278,39 @@ def test_draft_assistant_does_not_keep_product_title_as_only_included_item(clien
     payload = assistant.json()
     assert payload["ok"] is True
     assert not any("Was gehört alles zum Lieferumfang?\n\nJurassic World T-Rex Spielzeugfigur" == message["text"] for message in payload["messages"])
+
+
+def test_draft_assistant_uses_current_description_text_for_prefill_and_prompt(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "Lampe", "condition": "gut", "notes": "Erste Notiz", "accessories": "Kabel"},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+    client.post(
+        f"{location}/review",
+        data={
+            "title": "Lampe",
+            "condition": "gut",
+            "description": "Neue Beschreibung\nmit Absatz",
+            "included_items": "Kabel",
+            "action": "save",
+        },
+        follow_redirects=False,
+    )
+    client.post(f"{location}/assistant/message", json={"action": "confirm", "field": "title"})
+    client.post(f"{location}/assistant/message", json={"action": "confirm", "field": "condition"})
+    client.post(f"{location}/assistant/message", json={"action": "confirm", "field": "included_items"})
+
+    state = client.get(f"{location}/assistant/state")
+    payload = state.json()["assistant"]
+    description_message = next(message for message in payload["messages"] if message.get("field") == "description_html")
+    assert "Beschreibungsvorschlag:" in description_message["text"]
+    assert "Neue Beschreibung\nmit Absatz" in description_message["text"]
+    assert payload["fieldValues"]["description_html"] == "Neue Beschreibung\nmit Absatz"
 
 
 def test_draft_assistant_treats_unknown_values_as_unanswered(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -105,6 +105,29 @@ def test_post_upload_creates_draft_and_files(client: TestClient):
     assert len(normalized) == 2
 
 
+def test_post_upload_can_continue_asynchronously_in_same_chat(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"notes": "Leichte Spuren", "product_name": "Testgerät", "condition": "gut"},
+        headers={"Accept": "application/json"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["draftId"].startswith("draft_")
+    assert payload["location"].startswith("/drafts/")
+    assert payload["assistant"]["messages"]
+    assert payload["images"][0]["name"] == "front.jpg"
+
+    assistant_state = client.get(f"/drafts/{payload['draftId']}/assistant/state")
+    assert assistant_state.status_code == 200
+    assert assistant_state.json()["ok"] is True
+
+
 def test_draft_detail_can_trigger_analysis_again_from_ui(client: TestClient, monkeypatch: pytest.MonkeyPatch):
     files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
     response = client.post(
@@ -180,6 +203,32 @@ def test_draft_detail_exposes_assistant_flow_and_accepts_async_reply(client: Tes
 
     updated_detail = client.get(location)
     assert "Apple iPhone 13" in updated_detail.text
+
+
+def test_draft_assistant_can_confirm_category_without_page_reload(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "Lampe", "condition": "gut", "notes": "Kleine Lampe", "accessories": "Kabel"},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+    draft_id = location.rsplit("/", 1)[-1]
+
+    assistant = client.post(
+        f"/drafts/{draft_id}/assistant/message",
+        json={"action": "answer", "field": "category_suggestion", "value": "12345"},
+    )
+
+    assert assistant.status_code == 200
+    payload = assistant.json()
+    assert payload["ok"] is True
+
+    state = client.get(f"/drafts/{draft_id}/assistant/state")
+    assert state.status_code == 200
+    assert state.json()["draftId"] == draft_id
 
 
 def test_post_upload_without_images_returns_validation_error(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -164,9 +164,9 @@ def test_draft_detail_exposes_assistant_flow_and_accepts_async_reply(client: Tes
 
     location = response.headers["location"]
     detail = client.get(location)
-    assert "Assistenten-Flow" in detail.text
-    assert "Chat-artige Rückfragen ohne Reload" in detail.text
+    assert "Der Ablauf bleibt hier im Chat." in detail.text
     assert "Ich habe produktname erkannt" in detail.text
+    assert "Zurück" in detail.text
 
     assistant = client.post(
         f"{location}/assistant/message",

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -55,8 +55,10 @@ def test_upload_page_renders(client: TestClient):
     response = client.get("/drafts/upload")
 
     assert response.status_code == 200
-    assert "Mehrfach-Upload mit Vorschau" in response.text
-    assert "Draft erstellen" in response.text
+    assert "Hi, lade zuerst deine Bilder hoch." in response.text
+    assert "Bilder werden hier erst einmal nur hochgeladen" in response.text
+    assert "Wenn du magst, gib mir direkt noch ein paar Hinweise mit." in response.text
+    assert "Bilder senden" in response.text
 
 
 def test_post_upload_creates_draft_and_files(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -188,7 +188,7 @@ def test_draft_detail_exposes_assistant_flow_and_accepts_async_reply(client: Tes
     location = response.headers["location"]
     detail = client.get(location)
     assert "Der Ablauf bleibt hier im Chat." in detail.text
-    assert "Ich habe produktname erkannt" in detail.text
+    assert "Ich habe einen Produktnamen erkannt." in detail.text
     assert "Zurück" in detail.text
 
     assistant = client.post(
@@ -203,6 +203,32 @@ def test_draft_detail_exposes_assistant_flow_and_accepts_async_reply(client: Tes
 
     updated_detail = client.get(location)
     assert "Apple iPhone 13" in updated_detail.text
+
+
+def test_draft_assistant_uses_updated_title_for_follow_up_steps(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "DALI Lautsprecher Set", "condition": "gut", "notes": "Standlautsprecher mit Centerspeaker", "accessories": "Abdeckungen"},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+
+    assistant = client.post(
+        f"{location}/assistant/message",
+        json={"action": "answer", "field": "title", "value": "DALI Rubikore 6 + DALI Rubikore Cinema"},
+    )
+
+    assert assistant.status_code == 200
+    payload = assistant.json()
+    assert payload["ok"] is True
+    assert any("Produktname aktualisiert" in message["text"] for message in payload["messages"])
+    assert any("DALI Rubikore 6 + DALI Rubikore Cinema" in message["text"] for message in payload["messages"])
+
+    updated_detail = client.get(location)
+    assert "DALI Rubikore 6 + DALI Rubikore Cinema" in updated_detail.text
 
 
 def test_draft_assistant_can_confirm_category_without_page_reload(client: TestClient):

--- a/tests/test_upload_flow.py
+++ b/tests/test_upload_flow.py
@@ -151,6 +151,35 @@ def test_draft_detail_can_trigger_analysis_again_from_ui(client: TestClient, mon
     assert "Leichte Kratzer\nSchirm leicht verzogen" in detail.text
 
 
+def test_draft_detail_exposes_assistant_flow_and_accepts_async_reply(client: TestClient):
+    files = [("images", ("front.jpg", build_image_bytes(image_format="JPEG"), "image/jpeg"))]
+    response = client.post(
+        "/drafts/upload",
+        files=files,
+        data={"product_name": "iPhone", "condition": "gut", "notes": "Leichte Spuren", "accessories": "Ladekabel"},
+        follow_redirects=False,
+    )
+
+    location = response.headers["location"]
+    detail = client.get(location)
+    assert "Assistenten-Flow" in detail.text
+    assert "Chat-artige Rückfragen ohne Reload" in detail.text
+    assert "Ich habe produktname erkannt" in detail.text
+
+    assistant = client.post(
+        f"{location}/assistant/message",
+        json={"action": "answer", "field": "title", "value": "Apple iPhone 13"},
+    )
+
+    assert assistant.status_code == 200
+    payload = assistant.json()
+    assert payload["ok"] is True
+    assert any("Apple iPhone 13" in message["text"] for message in payload["messages"])
+
+    updated_detail = client.get(location)
+    assert "Apple iPhone 13" in updated_detail.text
+
+
 def test_post_upload_without_images_returns_validation_error(client: TestClient):
     response = client.post("/drafts/upload", data={"notes": "Ohne Bild"})
 


### PR DESCRIPTION
## Summary
- add a concrete assistant workflow on the draft detail page instead of keeping the issue at ADR level
- let users confirm or correct detected core listing data in a chat-like flow without full page reloads
- keep the existing review form as fallback while documenting the shipped beta flow in the README

## Testing
- `.venv/bin/python -m pytest tests/test_upload_flow.py -q`
- `.venv/bin/python -m pytest -q`

Closes #27
